### PR TITLE
Update zenpack info

### DIFF
--- a/resmgr/zenpacks.json
+++ b/resmgr/zenpacks.json
@@ -16,6 +16,7 @@
         "ZenPacks.zenoss.NtpMonitor",
         "ZenPacks.zenoss.ZenJMX",
         "ZenPacks.zenoss.LinuxMonitor",
+        "ZenPacks.zenoss.WBEM",
         "ZenPacks.zenoss.AuditLog",
         "ZenPacks.zenoss.DynamicView",
         "ZenPacks.zenoss.StorageBase",

--- a/resmgr/zenpacks.json
+++ b/resmgr/zenpacks.json
@@ -45,7 +45,6 @@
         "ZenPacks.zenoss.BrocadeMonitor",
         "ZenPacks.zenoss.WebsphereMonitor",
         "ZenPacks.zenoss.AixMonitor",
-        "ZenPacks.zenoss.EnterpriseLinux",
         "ZenPacks.zenoss.CheckPointMonitor",
         "ZenPacks.zenoss.AdvancedSearch",
         "ZenPacks.zenoss.Diagram",

--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -25,7 +25,7 @@
     },
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.AuditLog/1/artifact/dist/ZenPacks.zenoss.AuditLog-1.4.0-py2.7.egg",
-        "git_ref": "https://github.com/zenoss/ZenPacks.zenoss.AuditLog.git",
+        "git_ref": "1.4.0",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.AuditLog.git",
         "name": "ZenPacks.zenoss.AuditLog",
         "type": "download",

--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -384,12 +384,12 @@
         "version": "1.4.1"
     },
     {
-        "URL": "http://...",
-        "git_ref": "",
-        "git_repo": "",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.SupportBundle/4/artifact/dist/ZenPacks.zenoss.SupportBundle-1.1.0-py2.7.egg",
+        "git_ref": "1.1.0",
+        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.SupportBundle.git",
         "name": "ZenPacks.zenoss.SupportBundle",
         "type": "download",
-        "version": ""
+        "version": "1.1.0"
     },
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.TomcatMonitor/1/artifact/dist/ZenPacks.zenoss.TomcatMonitor-2.3.0-py2.7.egg",

--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -26,7 +26,7 @@
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.AuditLog/1/artifact/dist/ZenPacks.zenoss.AuditLog-1.4.0-py2.7.egg",
         "git_ref": "https://github.com/zenoss/ZenPacks.zenoss.AuditLog.git",
-        "git_repo": "1.4.0",
+        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.AuditLog.git",
         "name": "ZenPacks.zenoss.AuditLog",
         "type": "download",
         "version": "1.4.0"
@@ -58,7 +58,7 @@
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.CatalogService/3/artifact/dist/ZenPacks.zenoss.CatalogService-3.1.0-py2.7.egg",
         "git_ref": "3.1.0",
-        "git_repo": "ZenPacks.zenoss.CatalogService",
+        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.CatalogService.git",
         "name": "ZenPacks.zenoss.CatalogService",
         "type": "download",
         "version": "3.1.0"
@@ -122,7 +122,7 @@
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.DeviceSearch/3/artifact/dist/ZenPacks.zenoss.DeviceSearch-1.2.2-py2.7.egg",
         "git_ref": "1.2.2",
-        "git_repo": "ZenPacks.zenoss.DeviceSearch",
+        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.DeviceSearch.git",
         "name": "ZenPacks.zenoss.DeviceSearch",
         "type": "download",
         "version": "1.2.2"
@@ -130,7 +130,7 @@
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.Diagram/3/artifact/dist/ZenPacks.zenoss.Diagram-1.3.1-py2.7.egg",
         "git_ref": "1.3.1",
-        "git_repo": "ZenPacks.zenoss.Diagram",
+        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.Diagram.git",
         "name": "ZenPacks.zenoss.Diagram",
         "type": "download",
         "version": "1.3.1"
@@ -146,7 +146,7 @@
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.DistributedCollector/2/artifact/dist/ZenPacks.zenoss.DistributedCollector-3.1.0-py2.7.egg",
         "git_ref": "3.1.0",
-        "git_repo": "ZenPacks.zenoss.DistributedCollector",
+        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.DistributedCollector.git",
         "name": "ZenPacks.zenoss.DistributedCollector",
         "type": "download",
         "version": "3.1.0"
@@ -170,7 +170,7 @@
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseCollector/3/artifact/dist/ZenPacks.zenoss.EnterpriseCollector-1.7.0-py2.7.egg",
         "git_ref": "1.7.0",
-        "git_repo": "ZenPacks.zenoss.EnterpriseCollector",
+        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.EnterpriseCollector.git",
         "name": "ZenPacks.zenoss.EnterpriseCollector",
         "type": "download",
         "version": "1.7.0"
@@ -194,7 +194,7 @@
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseSecurity/2/artifact/dist/ZenPacks.zenoss.EnterpriseSecurity-1.2.0-py2.7.egg",
         "git_ref": "1.2.0",
-        "git_repo": "ZenPacks.zenoss.EnterpriseSecurity",
+        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.EnterpriseSecurity.git",
         "name": "ZenPacks.zenoss.EnterpriseSecurity",
         "type": "download",
         "version": "1.2.0"
@@ -202,7 +202,7 @@
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseSkin/2/artifact/dist/ZenPacks.zenoss.EnterpriseSkin-3.3.4-py2.7.egg",
         "git_ref": "3.3.4",
-        "git_repo": "ZenPacks.zenoss.EnterpriseSkin",
+        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.EnterpriseSkin.git",
         "name": "ZenPacks.zenoss.EnterpriseSkin",
         "type": "download",
         "version": "3.3.4"
@@ -258,7 +258,7 @@
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.LDAPAuthenticator/3/artifact/dist/ZenPacks.zenoss.LDAPAuthenticator-3.3.0-py2.7-linux-x86_64.egg",
         "git_ref": "3.3.0",
-        "git_repo": "ZenPacks.zenoss.LDAPAuthenticator",
+        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.LDAPAuthenticator.git",
         "name": "ZenPacks.zenoss.LDAPAuthenticator",
         "type": "download",
         "version": "3.3.0"
@@ -274,13 +274,13 @@
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.Licensing/2/artifact/dist/ZenPacks.zenoss.Licensing-0.2.0-py2.7.egg",
         "git_ref": "0.2.0",
-        "git_repo": "ZenPacks.zenoss.Licensing",
+        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.Licensing.git",
         "name": "ZenPacks.zenoss.Licensing",
         "type": "download",
         "version": "0.2.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.LinuxMonitor/8/artifact/dist/ZenPacks.zenoss.LinuxMonitor-2.0.3-py2.7.egg"
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.LinuxMonitor/8/artifact/dist/ZenPacks.zenoss.LinuxMonitor-2.0.3-py2.7.egg",
         "git_ref": "2.0.3",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.LinuxMonitor.git",
         "name": "ZenPacks.zenoss.LinuxMonitor",
@@ -410,7 +410,7 @@
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.WebLogicMonitor/2/artifact/dist/ZenPacks.zenoss.WebLogicMonitor-2.2.3-py2.7.egg",
         "git_ref": "2.2.3",
-        "git_repo": "ZenPacks.zenoss.WebLogicMonitor.git",
+        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.WebLogicMonitor.git",
         "name": "ZenPacks.zenoss.WebLogicMonitor",
         "type": "download",
         "version": "2.2.3"
@@ -426,7 +426,7 @@
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenDeviceACL/2/artifact/dist/ZenPacks.zenoss.ZenDeviceACL-2.2.0-py2.7.egg",
         "git_ref": "2.2.0",
-        "git_repo": "ZenPacks.zenoss.ZenDeviceACL",
+        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.ZenDeviceACL.git",
         "name": "ZenPacks.zenoss.ZenDeviceACL",
         "type": "download",
         "version": "2.2.0"
@@ -442,7 +442,7 @@
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenMail/2/artifact/dist/ZenPacks.zenoss.ZenMail-5.1.0-py2.7.egg",
         "git_ref": "5.1.0",
-        "git_repo": "ZenPacks.zenoss.ZenMail",
+        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.ZenMail.git",
         "name": "ZenPacks.zenoss.ZenMail",
         "type": "download",
         "version": "5.1.0"
@@ -458,7 +458,7 @@
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenOperatorRole/2/artifact/dist/ZenPacks.zenoss.ZenOperatorRole-2.1.0-py2.7.egg",
         "git_ref": "2.1.0",
-        "git_repo": "ZenPacks.zenoss.ZenOperatorRole",
+        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.ZenOperatorRole.git",
         "name": "ZenPacks.zenoss.ZenOperatorRole",
         "type": "download",
         "version": "2.1.0"

--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -1,6 +1,6 @@
 [
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.AdvancedSearch/3/artifact/dist/ZenPacks.zenoss.AdvancedSearch-1.2.0-py2.7.eg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.AdvancedSearch/3/artifact/dist/ZenPacks.zenoss.AdvancedSearch-1.2.0-py2.7.egg",
         "git_ref": "1.2.0",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.AdvancedSearch.git",
         "name": "ZenPacks.zenoss.AdvancedSearch",

--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -128,12 +128,12 @@
         "version": "1.2.2"
     },
     {
-        "URL": "http://...",
-        "git_ref": "",
-        "git_repo": "",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.Diagram/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.Diagram-1.3.1-py2.7.egg",
+        "git_ref": "1.3.1",
+        "git_repo": "ZenPacks.zenoss.Diagram",
         "name": "ZenPacks.zenoss.Diagram",
         "type": "download",
-        "version": ""
+        "version": "1.3.1"
     },
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.DigMonitor/2/artifact/dist/ZenPacks.zenoss.DigMonitor-1.1.0-py2.7.egg",
@@ -144,12 +144,12 @@
         "version": "1.1.0"
     },
     {
-        "URL": "http://...",
-        "git_ref": "",
-        "git_repo": "",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.DistributedCollector/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.DistributedCollector-3.1.0-py2.7.egg",
+        "git_ref": "3.1.0",
+        "git_repo": "ZenPacks.zenoss.DistributedCollector",
         "name": "ZenPacks.zenoss.DistributedCollector",
         "type": "download",
-        "version": ""
+        "version": "3.1.0"
     },
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.DnsMonitor/2/artifact/dist/ZenPacks.zenoss.DnsMonitor-2.1.0-py2.7.egg",
@@ -168,12 +168,12 @@
         "version": "1.4.0"
     },
     {
-        "URL": "http://...",
-        "git_ref": "",
-        "git_repo": "",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseCollector/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.EnterpriseCollector-1.7.0-py2.7.egg",
+        "git_ref": "1.7.0",
+        "git_repo": "ZenPacks.zenoss.EnterpriseCollector",
         "name": "ZenPacks.zenoss.EnterpriseCollector",
         "type": "download",
-        "version": ""
+        "version": "1.7.0"
     },
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseLinux/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.EnterpriseLinux-1.4.0-py2.7.egg",
@@ -192,12 +192,12 @@
         "version": "2.4.0"
     },
     {
-        "URL": "http://...",
-        "git_ref": "",
-        "git_repo": "",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseSecurity/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.EnterpriseSecurity-1.2.0-py2.7.egg",
+        "git_ref": "1.2.0",
+        "git_repo": "ZenPacks.zenoss.EnterpriseSecurity",
         "name": "ZenPacks.zenoss.EnterpriseSecurity",
         "type": "download",
-        "version": ""
+        "version": "1.2.0"
     },
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseSkin/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.EnterpriseSkin-3.3.4-py2.7.egg",
@@ -256,12 +256,12 @@
         "version": "2.1.1"
     },
     {
-        "URL": "http://...",
-        "git_ref": "",
-        "git_repo": "",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.LDAPAuthenticator/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.LDAPAuthenticator-3.3.0-py2.7-linux-x86_64.egg",
+        "git_ref": "3.3.0",
+        "git_repo": "ZenPacks.zenoss.LDAPAuthenticator",
         "name": "ZenPacks.zenoss.LDAPAuthenticator",
         "type": "download",
-        "version": ""
+        "version": "3.3.0"
     },
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.LDAPMonitor/2/artifact/dist/ZenPacks.zenoss.LDAPMonitor-1.4.1-py2.7.egg",
@@ -272,12 +272,12 @@
         "version": "1.4.1"
     },
     {
-        "URL": "http://...",
-        "git_ref": "",
-        "git_repo": "",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.Licensing/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.Licensing-0.2.0-py2.7.egg",
+        "git_ref": "0.2.0",
+        "git_repo": "ZenPacks.zenoss.Licensing",
         "name": "ZenPacks.zenoss.Licensing",
         "type": "download",
-        "version": ""
+        "version": "0.2.0"
     },
     {
         "URL": "http://jenkins.zenosslabs.com/view/0%20-%20Master/job/master-ZenPacks.zenoss.LinuxMonitor/7/artifact/dist/ZenPacks.zenoss.LinuxMonitor-2.0.2-py2.7.egg",
@@ -424,12 +424,12 @@
         "version": "1.2.2"
     },
     {
-        "URL": "http://...",
-        "git_ref": "",
-        "git_repo": "",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenDeviceACL/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.ZenDeviceACL-2.2.0-py2.7.egg",
+        "git_ref": "2.2.0",
+        "git_repo": "ZenPacks.zenoss.ZenDeviceACL",
         "name": "ZenPacks.zenoss.ZenDeviceACL",
         "type": "download",
-        "version": ""
+        "version": "2.2.0"
     },
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenJMX/7/artifact/dist/ZenPacks.zenoss.ZenJMX-3.12.1-py2.7.egg",
@@ -440,12 +440,12 @@
         "version": "3.12.1"
     },
     {
-        "URL": "http://.....",
-        "git_ref": "",
-        "git_repo": "",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenMail/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.ZenMail-5.1.0-py2.7.egg",
+        "git_ref": "5.1.0",
+        "git_repo": "ZenPacks.zenoss.ZenMail",
         "name": "ZenPacks.zenoss.ZenMail",
         "type": "download",
-        "version": "blam"
+        "version": "5.1.0"
     },
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenMailTx/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.ZenMailTx-2.6.0-py2.7.egg",
@@ -456,12 +456,12 @@
         "version": "2.6.0"
     },
     {
-        "URL": "http://...",
-        "git_ref": "",
-        "git_repo": "",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenOperatorRole/2/artifact/dist/ZenPacks.zenoss.ZenOperatorRole-2.1.0-py2.7.egg",
+        "git_ref": "2.1.0",
+        "git_repo": "ZenPacks.zenoss.ZenOperatorRole",
         "name": "ZenPacks.zenoss.ZenOperatorRole",
         "type": "download",
-        "version": ""
+        "version": "2.1.0"
     },
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenSQLTx/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.ZenSQLTx-2.6.3-py2.7-linux-x86_64.egg",

--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -176,14 +176,6 @@
         "version": "1.7.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseLinux/5/artifact/dist/ZenPacks.zenoss.EnterpriseLinux-1.4.0-py2.7.egg",
-        "git_ref": "1.4.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.EnterpriseLinux.git",
-        "name": "ZenPacks.zenoss.EnterpriseLinux",
-        "type": "download",
-        "version": "1.4.0"
-    },
-    {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseReports/2/artifact/dist/ZenPacks.zenoss.EnterpriseReports-2.4.0-py2.7.egg",
         "git_ref": "2.4.0",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.EnterpriseReports.git",

--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -1,6 +1,6 @@
 [
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.AdvancedSearch/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.AdvancedSearch-1.2.0-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.AdvancedSearch/3/artifact/dist/ZenPacks.zenoss.AdvancedSearch-1.2.0-py2.7.eg",
         "git_ref": "1.2.0",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.AdvancedSearch.git",
         "name": "ZenPacks.zenoss.AdvancedSearch",
@@ -8,7 +8,7 @@
         "version": "1.2.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.AixMonitor/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.AixMonitor-2.2.1-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.AixMonitor/59/artifact/dist/ZenPacks.zenoss.AixMonitor-2.2.1-py2.7.egg",
         "git_ref": "2.2.1",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.AixMonitor.git",
         "name": "ZenPacks.zenoss.AixMonitor",
@@ -16,7 +16,7 @@
         "version": "2.2.1"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/view/0%20-%20Master/job/master-ZenPacks.zenoss.ApacheMonitor/3/artifact/dist/ZenPacks.zenoss.ApacheMonitor-2.1.4-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ApacheMonitor/3/artifact/dist/ZenPacks.zenoss.ApacheMonitor-2.1.4-py2.7.egg",
         "git_ref": "2.1.4",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.ApacheMonitor.git",
         "name": "ZenPacks.zenoss.ApacheMonitor",
@@ -32,7 +32,7 @@
         "version": "1.4.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.BigIpMonitor/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.BigIpMonitor-2.7.0-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.BigIpMonitor/8/artifact/dist/ZenPacks.zenoss.BigIpMonitor-2.7.0-py2.7.egg",
         "git_ref": "2.7.0",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.BigIpMonitor.git",
         "name": "ZenPacks.zenoss.BigIpMonitor",
@@ -40,7 +40,7 @@
         "version": "2.7.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.BrocadeMonitor/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.BrocadeMonitor-2.1.1-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.BrocadeMonitor/2/artifact/dist/ZenPacks.zenoss.BrocadeMonitor-2.1.1-py2.7.egg",
         "git_ref": "2.1.1",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.BrocadeMonitor.git",
         "name": "ZenPacks.zenoss.BrocadeMonitor",
@@ -56,7 +56,7 @@
         "version": "2.2.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/view/0%20-%20Master/job/master-ZenPacks.zenoss.CatalogService/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.CatalogService-3.1.0-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.CatalogService/3/artifact/dist/ZenPacks.zenoss.CatalogService-3.1.0-py2.7.egg",
         "git_ref": "3.1.0",
         "git_repo": "ZenPacks.zenoss.CatalogService",
         "name": "ZenPacks.zenoss.CatalogService",
@@ -64,7 +64,7 @@
         "version": "3.1.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.CheckPointMonitor/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.CheckPointMonitor-2.0.0-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.CheckPointMonitor/3/artifact/dist/ZenPacks.zenoss.CheckPointMonitor-2.0.0-py2.7.egg",
         "git_ref": "2.0.0",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.CheckPointMonitor.git",
         "name": "ZenPacks.zenoss.CheckPointMonitor",
@@ -72,7 +72,7 @@
         "version": "2.0.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.CiscoMonitor/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.CiscoMonitor-5.7.1-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.CiscoMonitor/39/artifact/dist/ZenPacks.zenoss.CiscoMonitor-5.7.1-py2.7.egg",
         "git_ref": "5.7.1",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.CiscoMonitor.git",
         "name": "ZenPacks.zenoss.CiscoMonitor",
@@ -80,7 +80,7 @@
         "version": "5.7.1"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.CiscoUCS/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.CiscoUCS-2.4.4-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.CiscoUCS/36/artifact/dist/ZenPacks.zenoss.CiscoUCS-2.4.4-py2.7.egg",
         "git_ref": "2.4.4",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.CiscoUCS.git",
         "name": "ZenPacks.zenoss.CiscoUCS",
@@ -88,7 +88,7 @@
         "version": "2.4.4"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ComponentGroups/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.ComponentGroups-1.1.1-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ComponentGroups/1/artifact/dist/ZenPacks.zenoss.ComponentGroups-1.1.1-py2.7.egg",
         "git_ref": "1.1.1",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.ComponentGroups.git",
         "name": "ZenPacks.zenoss.ComponentGroups",
@@ -96,7 +96,7 @@
         "version": "1.1.1"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ControlCenter/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.ControlCenter-1.2.2-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ControlCenter/9/artifact/dist/ZenPacks.zenoss.ControlCenter-1.2.2-py2.7.egg",
         "git_ref": "1.2.2",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.ControlCenter.git",
         "name": "ZenPacks.zenoss.ControlCenter",
@@ -120,7 +120,7 @@
         "version": "2.2.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.DeviceSearch/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.DeviceSearch-1.2.2-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.DeviceSearch/3/artifact/dist/ZenPacks.zenoss.DeviceSearch-1.2.2-py2.7.egg",
         "git_ref": "1.2.2",
         "git_repo": "ZenPacks.zenoss.DeviceSearch",
         "name": "ZenPacks.zenoss.DeviceSearch",
@@ -128,7 +128,7 @@
         "version": "1.2.2"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.Diagram/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.Diagram-1.3.1-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.Diagram/3/artifact/dist/ZenPacks.zenoss.Diagram-1.3.1-py2.7.egg",
         "git_ref": "1.3.1",
         "git_repo": "ZenPacks.zenoss.Diagram",
         "name": "ZenPacks.zenoss.Diagram",
@@ -144,7 +144,7 @@
         "version": "1.1.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.DistributedCollector/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.DistributedCollector-3.1.0-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.DistributedCollector/2/artifact/dist/ZenPacks.zenoss.DistributedCollector-3.1.0-py2.7.egg",
         "git_ref": "3.1.0",
         "git_repo": "ZenPacks.zenoss.DistributedCollector",
         "name": "ZenPacks.zenoss.DistributedCollector",
@@ -160,7 +160,7 @@
         "version": "2.1.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.DynamicView/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.DynamicView-1.4.0-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.DynamicView/1/artifact/dist/ZenPacks.zenoss.DynamicView-1.4.0-py2.7.egg",
         "git_ref": "1.4.0",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.DynamicView.git",
         "name": "ZenPacks.zenoss.DynamicView",
@@ -168,7 +168,7 @@
         "version": "1.4.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseCollector/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.EnterpriseCollector-1.7.0-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseCollector/3/artifact/dist/ZenPacks.zenoss.EnterpriseCollector-1.7.0-py2.7.egg",
         "git_ref": "1.7.0",
         "git_repo": "ZenPacks.zenoss.EnterpriseCollector",
         "name": "ZenPacks.zenoss.EnterpriseCollector",
@@ -176,7 +176,7 @@
         "version": "1.7.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseLinux/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.EnterpriseLinux-1.4.0-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseLinux/5/artifact/dist/ZenPacks.zenoss.EnterpriseLinux-1.4.0-py2.7.egg",
         "git_ref": "1.4.0",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.EnterpriseLinux.git",
         "name": "ZenPacks.zenoss.EnterpriseLinux",
@@ -184,7 +184,7 @@
         "version": "1.4.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseReports/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.EnterpriseReports-2.4.0-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseReports/2/artifact/dist/ZenPacks.zenoss.EnterpriseReports-2.4.0-py2.7.egg",
         "git_ref": "2.4.0",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.EnterpriseReports.git",
         "name": "ZenPacks.zenoss.EnterpriseReports",
@@ -192,7 +192,7 @@
         "version": "2.4.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseSecurity/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.EnterpriseSecurity-1.2.0-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseSecurity/2/artifact/dist/ZenPacks.zenoss.EnterpriseSecurity-1.2.0-py2.7.egg",
         "git_ref": "1.2.0",
         "git_repo": "ZenPacks.zenoss.EnterpriseSecurity",
         "name": "ZenPacks.zenoss.EnterpriseSecurity",
@@ -200,7 +200,7 @@
         "version": "1.2.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseSkin/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.EnterpriseSkin-3.3.4-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseSkin/2/artifact/dist/ZenPacks.zenoss.EnterpriseSkin-3.3.4-py2.7.egg",
         "git_ref": "3.3.4",
         "git_repo": "ZenPacks.zenoss.EnterpriseSkin",
         "name": "ZenPacks.zenoss.EnterpriseSkin",
@@ -224,7 +224,7 @@
         "version": "2.1.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.HpuxMonitor/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.HpuxMonitor-2.0.0-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.HpuxMonitor/4/artifact/dist/ZenPacks.zenoss.HpuxMonitor-2.0.0-py2.7.egg",
         "git_ref": "2.0.0",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.HpuxMonitor.git",
         "name": "ZenPacks.zenoss.HpuxMonitor",
@@ -232,7 +232,7 @@
         "version": "2.0.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/view/0%20-%20Master/job/master-ZenPacks.zenoss.HttpMonitor/2/artifact/dist/ZenPacks.zenoss.HttpMonitor-2.1.0-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.HttpMonitor/2/artifact/dist/ZenPacks.zenoss.HttpMonitor-2.1.0-py2.7.egg",
         "git_ref": "2.1.0",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.HttpMonitor.git",
         "name": "ZenPacks.zenoss.HttpMonitor",
@@ -240,7 +240,7 @@
         "version": "2.1.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.JBossMonitor/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.JBossMonitor-2.4.2-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.JBossMonitor/1/artifact/dist/ZenPacks.zenoss.JBossMonitor-2.4.2-py2.7.egg",
         "git_ref": "2.4.2",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.JBossMonitor.git",
         "name": "ZenPacks.zenoss.JBossMonitor",
@@ -248,7 +248,7 @@
         "version": "2.4.2"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.JuniperMonitor/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.JuniperMonitor-2.1.1-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.JuniperMonitor/4/artifact/dist/ZenPacks.zenoss.JuniperMonitor-2.1.1-py2.7.egg",
         "git_ref": "2.1.1",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.JuniperMonitor.git",
         "name": "ZenPacks.zenoss.JuniperMonitor",
@@ -256,7 +256,7 @@
         "version": "2.1.1"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.LDAPAuthenticator/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.LDAPAuthenticator-3.3.0-py2.7-linux-x86_64.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.LDAPAuthenticator/3/artifact/dist/ZenPacks.zenoss.LDAPAuthenticator-3.3.0-py2.7-linux-x86_64.egg",
         "git_ref": "3.3.0",
         "git_repo": "ZenPacks.zenoss.LDAPAuthenticator",
         "name": "ZenPacks.zenoss.LDAPAuthenticator",
@@ -272,7 +272,7 @@
         "version": "1.4.1"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.Licensing/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.Licensing-0.2.0-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.Licensing/2/artifact/dist/ZenPacks.zenoss.Licensing-0.2.0-py2.7.egg",
         "git_ref": "0.2.0",
         "git_repo": "ZenPacks.zenoss.Licensing",
         "name": "ZenPacks.zenoss.Licensing",
@@ -280,12 +280,12 @@
         "version": "0.2.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/view/0%20-%20Master/job/master-ZenPacks.zenoss.LinuxMonitor/7/artifact/dist/ZenPacks.zenoss.LinuxMonitor-2.0.2-py2.7.egg",
-        "git_ref": "2.0.2",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.LinuxMonitor/8/artifact/dist/ZenPacks.zenoss.LinuxMonitor-2.0.3-py2.7.egg"
+        "git_ref": "2.0.3",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.LinuxMonitor.git",
         "name": "ZenPacks.zenoss.LinuxMonitor",
         "type": "download",
-        "version": "2.0.2"
+        "version": "2.0.3"
     },
     {
         "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.Microsoft.Windows/51/artifact/dist/ZenPacks.zenoss.Microsoft.Windows-2.6.1-py2.7.egg",
@@ -296,7 +296,7 @@
         "version": "2.6.1"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/view/0%20-%20Master/job/master-ZenPacks.zenoss.MySqlMonitor/13/artifact/dist/ZenPacks.zenoss.MySqlMonitor-3.0.7-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.MySqlMonitor/13/artifact/dist/ZenPacks.zenoss.MySqlMonitor-3.0.7-py2.7.egg",
         "git_ref": "3.0.7",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.MySqlMonitor.git",
         "name": "ZenPacks.zenoss.MySqlMonitor",
@@ -304,7 +304,7 @@
         "version": "3.0.7"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.NetAppMonitor/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.NetAppMonitor-3.3.1-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.NetAppMonitor/14/artifact/dist/ZenPacks.zenoss.NetAppMonitor-3.3.1-py2.7.egg",
         "git_ref": "3.3.1",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.NetAppMonitor.git",
         "name": "ZenPacks.zenoss.NetAppMonitor",
@@ -312,7 +312,7 @@
         "version": "3.3.1"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.NetScaler/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.NetScaler-1.0.6-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.NetScaler/9/artifact/dist/ZenPacks.zenoss.NetScaler-1.0.6-py2.7.egg",
         "git_ref": "1.0.6",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.NetScaler.git",
         "name": "ZenPacks.zenoss.NetScaler",
@@ -320,7 +320,7 @@
         "version": "1.0.6"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.NetScreenMonitor/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.NetScreenMonitor-2.2.0-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.NetScreenMonitor/1/artifact/dist/ZenPacks.zenoss.NetScreenMonitor-2.2.0-py2.7.egg",
         "git_ref": "2.2.0",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.NetScreenMonitor.git",
         "name": "ZenPacks.zenoss.NetScreenMonitor",
@@ -328,7 +328,7 @@
         "version": "2.2.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.NortelMonitor/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.NortelMonitor-2.0.2-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.NortelMonitor/1/artifact/dist/ZenPacks.zenoss.NortelMonitor-2.0.2-py2.7.egg",
         "git_ref": "2.0.2",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.NortelMonitor.git",
         "name": "ZenPacks.zenoss.NortelMonitor",
@@ -336,7 +336,7 @@
         "version": "2.0.2"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/view/0%20-%20Master/job/master-ZenPacks.zenoss.NtpMonitor/4/artifact/dist/ZenPacks.zenoss.NtpMonitor-2.2.2-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.NtpMonitor/4/artifact/dist/ZenPacks.zenoss.NtpMonitor-2.2.2-py2.7.egg",
         "git_ref": "2.2.2",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.NtpMonitor.git",
         "name": "ZenPacks.zenoss.NtpMonitor",
@@ -344,7 +344,7 @@
         "version": "2.2.2"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.PredictiveThreshold/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.PredictiveThreshold-1.1.1-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.PredictiveThreshold/4/artifact/dist/ZenPacks.zenoss.PredictiveThreshold-1.1.1-py2.7.egg",
         "git_ref": "1.1.1",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.PredictiveThreshold.git",
         "name": "ZenPacks.zenoss.PredictiveThreshold",
@@ -352,7 +352,7 @@
         "version": "1.1.1"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.PropertyMonitor/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.PropertyMonitor-1.1.0-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.PropertyMonitor/4/artifact/dist/ZenPacks.zenoss.PropertyMonitor-1.1.0-py2.7.egg",
         "git_ref": "1.1.0",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.PropertyMonitor.git",
         "name": "ZenPacks.zenoss.PropertyMonitor",
@@ -360,7 +360,7 @@
         "version": "1.1.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/view/0%20-%20Master/job/master-ZenPacks.zenoss.PythonCollector/28/artifact/dist/ZenPacks.zenoss.PythonCollector-1.8.1-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.PythonCollector/28/artifact/dist/ZenPacks.zenoss.PythonCollector-1.8.1-py2.7.egg",
         "git_ref": "1.8.1",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.PythonCollector.git",
         "name": "ZenPacks.zenoss.PythonCollector",
@@ -368,7 +368,7 @@
         "version": "1.8.1"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.SolarisMonitor/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.SolarisMonitor-2.4.1-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.SolarisMonitor/10/artifact/dist/ZenPacks.zenoss.SolarisMonitor-2.4.1-py2.7.egg",
         "git_ref": "2.4.1",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.SolarisMonitor.git",
         "name": "ZenPacks.zenoss.SolarisMonitor",
@@ -376,7 +376,7 @@
         "version": "2.4.1"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.StorageBase/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.StorageBase-1.4.1-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.StorageBase/8/artifact/dist/ZenPacks.zenoss.StorageBase-1.4.1-py2.7.egg",
         "git_ref": "1.4.1",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.StorageBase.git",
         "name": "ZenPacks.zenoss.StorageBase",
@@ -392,7 +392,7 @@
         "version": ""
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.TomcatMonitor/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.TomcatMonitor-2.3.0-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.TomcatMonitor/1/artifact/dist/ZenPacks.zenoss.TomcatMonitor-2.3.0-py2.7.egg",
         "git_ref": "2.3.0",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.TomcatMonitor.git",
         "name": "ZenPacks.zenoss.TomcatMonitor",
@@ -408,23 +408,23 @@
         "version": "1.0.3"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.WebLogicMonitor/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.WebLogicMonitor-2.2.3-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.WebLogicMonitor/2/artifact/dist/ZenPacks.zenoss.WebLogicMonitor-2.2.3-py2.7.egg",
         "git_ref": "2.2.3",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.WebLogicMonitor.git",
+        "git_repo": "ZenPacks.zenoss.WebLogicMonitor.git",
         "name": "ZenPacks.zenoss.WebLogicMonitor",
         "type": "download",
         "version": "2.2.3"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.WebsphereMonitor/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.WebsphereMonitor-1.2.2-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.WebsphereMonitor/2/artifact/dist/ZenPacks.zenoss.WebsphereMonitor-1.2.2-py2.7.egg",
         "git_ref": "1.2.2",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.WebshpereMonitor.git",
+        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.WebsphereMonitor.git",
         "name": "ZenPacks.zenoss.WebsphereMonitor",
         "type": "download",
         "version": "1.2.2"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenDeviceACL/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.ZenDeviceACL-2.2.0-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenDeviceACL/2/artifact/dist/ZenPacks.zenoss.ZenDeviceACL-2.2.0-py2.7.egg",
         "git_ref": "2.2.0",
         "git_repo": "ZenPacks.zenoss.ZenDeviceACL",
         "name": "ZenPacks.zenoss.ZenDeviceACL",
@@ -440,7 +440,7 @@
         "version": "3.12.1"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenMail/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.ZenMail-5.1.0-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenMail/2/artifact/dist/ZenPacks.zenoss.ZenMail-5.1.0-py2.7.egg",
         "git_ref": "5.1.0",
         "git_repo": "ZenPacks.zenoss.ZenMail",
         "name": "ZenPacks.zenoss.ZenMail",
@@ -448,7 +448,7 @@
         "version": "5.1.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenMailTx/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.ZenMailTx-2.6.0-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenMailTx/4/artifact/dist/ZenPacks.zenoss.ZenMailTx-2.6.0-py2.7.egg",
         "git_ref": "2.6.0",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.ZenMailTx.git",
         "name": "ZenPacks.zenoss.ZenMailTx",
@@ -464,7 +464,7 @@
         "version": "2.1.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenSQLTx/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.ZenSQLTx-2.6.3-py2.7-linux-x86_64.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenSQLTx/5/artifact/dist/ZenPacks.zenoss.ZenSQLTx-2.6.3-py2.7-linux-x86_64.egg",
         "git_ref": "2.6.3",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.ZenSQLTx.git",
         "name": "ZenPacks.zenoss.ZenSQLTx",
@@ -472,7 +472,7 @@
         "version": "2.6.3"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenWebTx/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.ZenWebTx-3.0.0-py2.7.egg",
+        "URL":  "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenWebTx/9/artifact/dist/ZenPacks.zenoss.ZenWebTx-3.0.0-py2.7.egg",
         "git_ref": "3.0.0",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.ZenWebTx.git",
         "name": "ZenPacks.zenoss.ZenWebTx",
@@ -480,7 +480,7 @@
         "version": "3.0.0"
     },
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.vCloud/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.vCloud-1.4.9-py2.7.egg",
+        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.vCloud/6/artifact/dist/ZenPacks.zenoss.vCloud-1.4.9-py2.7.egg",
         "git_ref": "1.4.9",
         "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.vCloud.git",
         "name": "ZenPacks.zenoss.vCloud",


### PR DESCRIPTION
Short of overlooking a ZP, this PR should finish off the initial set of zenpacks for Metis Core and RM.  There are 4 separate commits that detail the different operations - basically, filling in missing gaps and normalizing some discrepancies.