### PR TITLE
move zenoss python libs from base image to here. Strict pip installs …

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -32,6 +32,14 @@
         "version": "1.1.2"
     },
     {
+        "URL": "http://zenpip.zendev.org/packages/pynetsnmp-0.40.6-py2-none-any.whl",
+        "git_ref": "0.40.6",
+        "git_repo": "https://github.com/zenoss/pynetsnmp.git",
+        "name": "pynetsnmp",
+        "type": "download",
+        "version": "0.40.6"
+    },
+    {
         "URL": "http://zenpip.zendev.org/packages/redis-mon-0.1.2.tgz",
         "git_ref": "0.1.2",
         "git_repo": "https://github.com/zenoss/redis-mon.git",
@@ -48,26 +56,42 @@
         "version": "1.1.1"
     },
     {
-        "jenkinsInfo": {
-            "server": "http://jenkins.zendev.org",
-            "job": "prodbin-merge-develop",
-            "pattern": "prodbin*.tar.gz"
-        },
+        "URL": "http://zenpip.zendev.org/packages/zenoss.extjs-4.1.3.tar.gz",
+        "git_ref": "master",
+        "git_repo": "https://github.com/zenoss/zenoss-extjs.git",
+        "name": "zenoss-extjs",
+        "type": "download",
+        "version": "4.1.3"
+    },
+    {
         "git_ref": "develop",
         "git_repo": "https://github.com/zenoss/zenoss-prodbin.git",
+        "jenkinsInfo": {
+            "job": "prodbin-merge-develop",
+            "pattern": "prodbin*.tar.gz",
+            "server": "http://jenkins.zendev.org"
+        },
         "name": "zenoss-prodbin",
         "type": "jenkins",
         "version": "develop"
     },
     {
-        "jenkinsInfo": {
-            "server": "http://jenkins.zendev.org",
-            "job": "zenoss-zep-develop",
-            "subModule": "org.zenoss.zep$zep-dist",
-            "pattern": "zep*.tar.gz"
-        },
+        "URL": "http://zenpip.zendev.org/packages/zenoss.protocols-2.1.4.post1-py2-none-any.whl",
+        "git_ref": "2.1.4-1",
+        "git_repo": "https://github.com/zenoss/zenoss-protocols.git",
+        "name": "zenoss-protocols",
+        "type": "download",
+        "version": "2.1.4-1"
+    },
+    {
         "git_ref": "develop",
         "git_repo": "https://github.com/zenoss/zenoss-zep.git",
+        "jenkinsInfo": {
+            "job": "zenoss-zep-develop",
+            "pattern": "zep*.tar.gz",
+            "server": "http://jenkins.zendev.org",
+            "subModule": "org.zenoss.zep$zep-dist"
+        },
         "name": "zep",
         "type": "jenkins",
         "version": "develop"

--- a/product-base/Dockerfile
+++ b/product-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM zenoss/zenoss-centos-base:1.2.2
+FROM zenoss/zenoss-centos-base:1.2.3
 
 # maintener is redundant since base image is ours as well
 #MAINTAINER Zenoss <dev@zenoss.com>

--- a/product-base/install_scripts/zenoss_component_install.sh
+++ b/product-base/install_scripts/zenoss_component_install.sh
@@ -19,10 +19,9 @@ su - zenoss -c "tar -C ${ZENHOME} -xzvf /tmp/prodbin*"
 su - zenoss -c "mkdir -p ${ZENHOME}/etc/supervisor"
 su - zenoss -c "ln -s ${ZENHOME}/etc/zauth/zauth_supervisor.conf ${ZENHOME}/etc/supervisor/zauth_supervisor.conf"
 
-su - zenoss -c "pip install ${ZENHOME}/dist/*.whl"
+su - zenoss -c "pip install  --use-wheel --no-index  ${ZENHOME}/dist/*.whl"
 su - zenoss -c "mv ${ZENHOME}/legacy/sitecustomize.py ${ZENHOME}/lib/python2.7/"
 su - zenoss -c "rm -rf ${ZENHOME}/dist ${ZENHOME}/legacy"
-
 
 
 # Install MetricConsumer
@@ -45,7 +44,19 @@ su - zenoss -c "ln -s ${ZENHOME}/etc/central-query/central-query_supervisor.conf
 artifactDownload "icmpecho"
 su - zenoss -c "tar -C /tmp -xzvf /tmp/icmpecho*"
 su - zenoss -c "mv /tmp/pyraw ${ZENHOME}/bin"
-su - zenoss -c "pip install /tmp/icmpecho*.whl"
+su - zenoss -c "pip install  --use-wheel --no-index  /tmp/icmpecho*.whl"
+
+# Install zenoss-protocols
+artifactDownload "zenoss-protocols"
+su - zenoss -c "pip install  --use-wheel --no-index  /tmp/zenoss.protocols*.whl"
+
+# Install pynetsnmp
+artifactDownload "pynetsnmp"
+su - zenoss -c "pip install  --use-wheel --no-index  /tmp/pynetsnmp*.whl"
+
+# Install zenoss-extjs
+artifactDownload "zenoss-extjs"
+su - zenoss -c "pip install  --no-index  /tmp/zenoss.extjs*"
 
 # Install zep
 artifactDownload "zep" 
@@ -69,7 +80,7 @@ su - zenoss -c "tar --strip-components=2 -C ${ZENHOME} -xzvf /tmp/zproxy*"
 
 
 artifactDownload "servicemigration"
-su - zenoss -c "pip install /tmp/servicemigration*"
+su - zenoss -c "pip install  --use-wheel --no-index  /tmp/servicemigration*"
 
 # TODO add upgrade templates to /root  - probably done in core/rm image builds
 


### PR DESCRIPTION
…so it won't download new libs