### PR TITLE
Add download logs to the product images

### DIFF
--- a/Jenkins-image.groovy
+++ b/Jenkins-image.groovy
@@ -19,7 +19,8 @@ node ('build-zenoss-product') {
         //       The next checkout command will align the build with the correct target revision.
         git branch: 'master', credentialsId: '${GIT_CREDENTIAL_ID}', url: 'https://github.com/zenoss/product-assembly'
         sh("git checkout ${GIT_SHA}")
-        sh("cd ${TARGET_PRODUCT};MATURITY=${MATURITY} BUILD_NUMBER=${PRODUCT_BUILD_NUMBER} make clean build")
+        sh("cd ${TARGET_PRODUCT};MATURITY=${MATURITY} BUILD_NUMBER=${PRODUCT_BUILD_NUMBER} make clean build getDownloadLogs")
+        archive includes: '${TARGET_PRODUCT}/*.log'
 
     stage 'Push image'
         sh("cd ${TARGET_PRODUCT};MATURITY=${MATURITY} BUILD_NUMBER=${PRODUCT_BUILD_NUMBER} make push")

--- a/artifact_download.py
+++ b/artifact_download.py
@@ -37,7 +37,7 @@ def urlDownload(versionInfo, outdir, downloadReport):
     artifactInfo = {}
     artifactInfo['name'] = versionInfo['name']
     artifactInfo['version'] = versionInfo['version']
-    artifactInfo['downloader'] = 'download'
+    artifactInfo['type'] = 'releasedArtifact'
     downloadReport.append(artifactInfo)
 
 #
@@ -123,7 +123,7 @@ def jenkinsDownload(versionInfo, outdir, downloadReport):
             #
             artifactInfo = {}
             artifactInfo['name'] = versionInfo['name']
-            artifactInfo['downloader'] = 'jenkins'
+            artifactInfo['type'] = 'jenkinsBuild'
             artifactInfo['version'] = versionInfo['version']
             artifactInfo['job_nbr'] = number
             artifactInfo['git_ref'] = git_ref

--- a/artifact_download.py
+++ b/artifact_download.py
@@ -125,9 +125,10 @@ def jenkinsDownload(versionInfo, outdir, downloadReport):
             artifactInfo['name'] = versionInfo['name']
             artifactInfo['type'] = 'jenkinsBuild'
             artifactInfo['version'] = versionInfo['version']
-            artifactInfo['job_nbr'] = number
             artifactInfo['git_ref'] = git_ref
             artifactInfo['git_branch'] = git_branch
+            artifactInfo['jenkinsInfo'] = jenkinsInfo
+            artifactInfo['jenkinsInfo']['job_nbr'] = number
             downloadReport.append(artifactInfo)
 
     if nDownloaded == 0:

--- a/core/Dockerfile.in
+++ b/core/Dockerfile.in
@@ -8,6 +8,7 @@ ADD licenses.core.html /opt/zenoss/Products/ZenUI3/docs/licenses.html
 
 # the manifest of zenpacks to install
 ADD zenpacks.json /opt/zenoss/install_scripts/
+ADD zenpacks_install.log /opt/zenoss/log/
 
 # the zenpacks shipped in the images
 COPY zenpacks /opt/zenoss/packs/

--- a/core/makefile
+++ b/core/makefile
@@ -8,7 +8,7 @@ FROM_IMAGE = product-base:$(VERSION)_$(BUILD_NUMBER)_$(MATURITY)
 
 TAG = zenoss/$(IMAGENAME):$(VERSION)_$(BUILD_NUMBER)_$(MATURITY)
 
-.PHONY: build push clean
+.PHONY: build push clean getDownloadLogs
 
 
 build: Dockerfile zenpack_download
@@ -30,4 +30,9 @@ push:
 clean:
 	rm -rf zenpacks
 	rm -f Dockerfile
+	rm -f zenoss_component_install.log
+	rm -f zenpacks_install.log
 	-docker rmi -f $(TAG)
+
+getDownloadLogs:
+	docker run --rm -v $(PWD):/mnt/export -ti $(TAG) rsync -a /opt/zenoss/log/zenoss_component_install.log /opt/zenoss/log/zenpacks_install.log /mnt/export

--- a/core/makefile
+++ b/core/makefile
@@ -22,7 +22,7 @@ zenpacks:
 	@mkdir zenpacks
 
 zenpack_download: zenpacks
-	../artifact_download.py ../zenpack_versions.json --zp_manifest zenpacks.json --out_dir zenpacks
+	../artifact_download.py ../zenpack_versions.json --zp_manifest zenpacks.json --out_dir zenpacks --reportFile zenpacks_install.log
 
 push:
 	docker push $(TAG)

--- a/product-base/install_scripts/zenoss_component_install.sh
+++ b/product-base/install_scripts/zenoss_component_install.sh
@@ -3,13 +3,16 @@
 set -e
 set -x
 
+mkdir -p ${ZENHOME}/log/
+
 #Files added via docker will be owned by root, set to zenoss
 chown -Rf zenoss:zenoss ${ZENHOME}/*
+
 
 function artifactDownload
 {
     local artifact="$@"
-    su - zenoss -c "${ZENHOME}/install_scripts/artifact_download.py --out_dir /tmp ${ZENHOME}/install_scripts/component_versions.json ${artifact}"
+    su - zenoss -c "${ZENHOME}/install_scripts/artifact_download.py --out_dir /tmp ${ZENHOME}/install_scripts/component_versions.json ${artifact} --reportFile ${ZENHOME}/log/zenoss_component_install.log"
 }
 
 # Install Prodbin
@@ -61,7 +64,7 @@ artifactDownload "zenoss-extjs"
 su - zenoss -c "pip install  --no-index  /tmp/zenoss.extjs*"
 
 # Install zep
-artifactDownload "zep" 
+artifactDownload "zep"
 su - zenoss -c "tar -C ${ZENHOME} -xzvf /tmp/zep-dist*"
 
 # Install metricshipper

--- a/resmgr/Dockerfile.in
+++ b/resmgr/Dockerfile.in
@@ -8,6 +8,7 @@ ADD licenses.resmgr.html /opt/zenoss/Products/ZenUI3/docs/licenses.html
 
 # the manifest of zenpacks to install
 ADD zenpacks.json /opt/zenoss/install_scripts/
+ADD zenpacks_install.log /opt/zenoss/log/
 
 # the zenpacks shipped in the images
 COPY zenpacks /opt/zenoss/packs/

--- a/resmgr/makefile
+++ b/resmgr/makefile
@@ -8,7 +8,7 @@ FROM_IMAGE = product-base:$(VERSION)_$(BUILD_NUMBER)_$(MATURITY)
 
 TAG = zenoss/$(IMAGENAME):$(VERSION)_$(BUILD_NUMBER)_$(MATURITY)
 
-.PHONY: build push clean
+.PHONY: build push clean getDownloadLogs
 
 
 build: Dockerfile zenpack_download
@@ -30,4 +30,9 @@ push:
 clean:
 	rm -rf zenpacks
 	rm -f Dockerfile
+	rm -f zenoss_component_install.log
+	rm -f zenpacks_install.log
 	-docker rmi -f $(TAG)
+
+getDownloadLogs:
+	docker run --rm -v $(PWD):/mnt/export -ti $(TAG) rsync -a /opt/zenoss/log/zenoss_component_install.log /opt/zenoss/log/zenpacks_install.log /mnt/export

--- a/resmgr/makefile
+++ b/resmgr/makefile
@@ -22,7 +22,7 @@ zenpacks:
 	@mkdir zenpacks
 
 zenpack_download: zenpacks
-	../artifact_download.py ../zenpack_versions.json --zp_manifest zenpacks.json --out_dir zenpacks
+	../artifact_download.py ../zenpack_versions.json --zp_manifest zenpacks.json --out_dir zenpacks --reportFile zenpacks_install.log
 
 push:
 	docker push $(TAG)


### PR DESCRIPTION
Gives QA a breadcrumb trail about which builds/git-refs went into a particular build for nightlies.