### PR TITLE
Add "zenpack" downloader type

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -1,494 +1,187 @@
 [
     {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.AdvancedSearch/3/artifact/dist/ZenPacks.zenoss.AdvancedSearch-1.2.0-py2.7.egg",
-        "git_ref": "1.2.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.AdvancedSearch.git",
         "name": "ZenPacks.zenoss.AdvancedSearch",
-        "type": "download",
-        "version": "1.2.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.AixMonitor/59/artifact/dist/ZenPacks.zenoss.AixMonitor-2.2.1-py2.7.egg",
-        "git_ref": "2.2.1",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.AixMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.AixMonitor",
-        "type": "download",
-        "version": "2.2.1"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ApacheMonitor/3/artifact/dist/ZenPacks.zenoss.ApacheMonitor-2.1.4-py2.7.egg",
-        "git_ref": "2.1.4",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.ApacheMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.ApacheMonitor",
-        "type": "download",
-        "version": "2.1.4"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.AuditLog/1/artifact/dist/ZenPacks.zenoss.AuditLog-1.4.0-py2.7.egg",
-        "git_ref": "1.4.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.AuditLog.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.AuditLog",
-        "type": "download",
-        "version": "1.4.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.BigIpMonitor/8/artifact/dist/ZenPacks.zenoss.BigIpMonitor-2.7.0-py2.7.egg",
-        "git_ref": "2.7.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.BigIpMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.BigIpMonitor",
-        "type": "download",
-        "version": "2.7.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.BrocadeMonitor/2/artifact/dist/ZenPacks.zenoss.BrocadeMonitor-2.1.1-py2.7.egg",
-        "git_ref": "2.1.1",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.BrocadeMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.BrocadeMonitor",
-        "type": "download",
-        "version": ""
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.CalculatedPerformance/12/artifact/dist/ZenPacks.zenoss.CalculatedPerformance-2.2.1-py2.7.egg",
-        "git_ref": "2.2.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.CalculatedPerformance.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.CalculatedPerformance",
-        "type": "download",
-        "version": "2.2.0"
-    },
-    {
-        "git_ref": "develop",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.CatalogService.git",
-        "jenkinsInfo": {
-            "job": "develop-ZenPacks.zenoss.CatalogService",
-            "pattern": "ZenPacks.zenoss.CatalogService-*-py2.7.egg",
-            "server": "http://jenkins.zenosslabs.com/"
-        },
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.CatalogService",
-        "type": "jenkins",
-        "version": "develop"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.CheckPointMonitor/3/artifact/dist/ZenPacks.zenoss.CheckPointMonitor-2.0.0-py2.7.egg",
-        "git_ref": "2.0.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.CheckPointMonitor.git",
+        "type": "zenpack",
+        "pre": true
+    },{
         "name": "ZenPacks.zenoss.CheckPointMonitor",
-        "type": "download",
-        "version": "2.0.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.CiscoMonitor/39/artifact/dist/ZenPacks.zenoss.CiscoMonitor-5.7.1-py2.7.egg",
-        "git_ref": "5.7.1",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.CiscoMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.CiscoMonitor",
-        "type": "download",
-        "version": "5.7.1"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.CiscoUCS/36/artifact/dist/ZenPacks.zenoss.CiscoUCS-2.4.4-py2.7.egg",
-        "git_ref": "2.4.4",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.CiscoUCS.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.CiscoUCS",
-        "type": "download",
-        "version": "2.4.4"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ComponentGroups/1/artifact/dist/ZenPacks.zenoss.ComponentGroups-1.1.1-py2.7.egg",
-        "git_ref": "1.1.1",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.ComponentGroups.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.ComponentGroups",
-        "type": "download",
-        "version": "1.1.1"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ControlCenter/9/artifact/dist/ZenPacks.zenoss.ControlCenter-1.2.2-py2.7.egg",
-        "git_ref": "1.2.2",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.ControlCenter.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.ControlCenter",
-        "type": "download",
-        "version": "1.2.2"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.Dashboard/1/artifact/dist/ZenPacks.zenoss.Dashboard-1.2.1-py2.7.egg",
-        "git_ref": "1.2.1",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.Dashboard.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.Dashboard",
-        "type": "download",
-        "version": "1.2.1"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.DellMonitor/2/artifact/dist/ZenPacks.zenoss.DellMonitor-2.2.0-py2.7.egg",
-        "git_ref": "2.2.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.DellMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.DellMonitor",
-        "type": "download",
-        "version": "2.2.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.DeviceSearch/3/artifact/dist/ZenPacks.zenoss.DeviceSearch-1.2.2-py2.7.egg",
-        "git_ref": "1.2.2",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.DeviceSearch.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.DeviceSearch",
-        "type": "download",
-        "version": "1.2.2"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.Diagram/3/artifact/dist/ZenPacks.zenoss.Diagram-1.3.1-py2.7.egg",
-        "git_ref": "1.3.1",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.Diagram.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.Diagram",
-        "type": "download",
-        "version": "1.3.1"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.DigMonitor/2/artifact/dist/ZenPacks.zenoss.DigMonitor-1.1.0-py2.7.egg",
-        "git_ref": "1.1.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.DigMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.DigMonitor",
-        "type": "download",
-        "version": "1.1.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.DistributedCollector/2/artifact/dist/ZenPacks.zenoss.DistributedCollector-3.1.0-py2.7.egg",
-        "git_ref": "3.1.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.DistributedCollector.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.DistributedCollector",
-        "type": "download",
-        "version": "3.1.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.DnsMonitor/2/artifact/dist/ZenPacks.zenoss.DnsMonitor-2.1.0-py2.7.egg",
-        "git_ref": "2.1.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.DigMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.DnsMonitor",
-        "type": "download",
-        "version": "2.1.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.DynamicView/1/artifact/dist/ZenPacks.zenoss.DynamicView-1.4.0-py2.7.egg",
-        "git_ref": "1.4.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.DynamicView.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.DynamicView",
-        "type": "download",
-        "version": "1.4.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseCollector/3/artifact/dist/ZenPacks.zenoss.EnterpriseCollector-1.7.0-py2.7.egg",
-        "git_ref": "1.7.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.EnterpriseCollector.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.EnterpriseCollector",
-        "type": "download",
-        "version": "1.7.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseReports/2/artifact/dist/ZenPacks.zenoss.EnterpriseReports-2.4.0-py2.7.egg",
-        "git_ref": "2.4.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.EnterpriseReports.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.EnterpriseReports",
-        "type": "download",
-        "version": "2.4.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseSecurity/2/artifact/dist/ZenPacks.zenoss.EnterpriseSecurity-1.2.0-py2.7.egg",
-        "git_ref": "1.2.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.EnterpriseSecurity.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.EnterpriseSecurity",
-        "type": "download",
-        "version": "1.2.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.EnterpriseSkin/2/artifact/dist/ZenPacks.zenoss.EnterpriseSkin-3.3.4-py2.7.egg",
-        "git_ref": "3.3.4",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.EnterpriseSkin.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.EnterpriseSkin",
-        "type": "download",
-        "version": "3.3.4"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.FtpMonitor/2/artifact/dist/ZenPacks.zenoss.FtpMonitor-1.1.0-py2.7.egg",
-        "git_ref": "1.1.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.FtpMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.FtpMonitor",
-        "type": "download",
-        "version": "1.1.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.HPMonitor/2/artifact/dist/ZenPacks.zenoss.HPMonitor-2.1.0-py2.7.egg",
-        "git_ref": "2.1.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.HPMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.HPMonitor",
-        "type": "download",
-        "version": "2.1.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.HpuxMonitor/4/artifact/dist/ZenPacks.zenoss.HpuxMonitor-2.0.0-py2.7.egg",
-        "git_ref": "2.0.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.HpuxMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.HpuxMonitor",
-        "type": "download",
-        "version": "2.0.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.HttpMonitor/2/artifact/dist/ZenPacks.zenoss.HttpMonitor-2.1.0-py2.7.egg",
-        "git_ref": "2.1.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.HttpMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.HttpMonitor",
-        "type": "download",
-        "version": "2.1.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.JBossMonitor/1/artifact/dist/ZenPacks.zenoss.JBossMonitor-2.4.2-py2.7.egg",
-        "git_ref": "2.4.2",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.JBossMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.JBossMonitor",
-        "type": "download",
-        "version": "2.4.2"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.JuniperMonitor/4/artifact/dist/ZenPacks.zenoss.JuniperMonitor-2.1.1-py2.7.egg",
-        "git_ref": "2.1.1",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.JuniperMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.JuniperMonitor",
-        "type": "download",
-        "version": "2.1.1"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.LDAPAuthenticator/3/artifact/dist/ZenPacks.zenoss.LDAPAuthenticator-3.3.0-py2.7-linux-x86_64.egg",
-        "git_ref": "3.3.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.LDAPAuthenticator.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.LDAPAuthenticator",
-        "type": "download",
-        "version": "3.3.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.LDAPMonitor/2/artifact/dist/ZenPacks.zenoss.LDAPMonitor-1.4.1-py2.7.egg",
-        "git_ref": "1.4.1",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.LDAPMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.LDAPMonitor",
-        "type": "download",
-        "version": "1.4.1"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.Licensing/2/artifact/dist/ZenPacks.zenoss.Licensing-0.2.0-py2.7.egg",
-        "git_ref": "0.2.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.Licensing.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.Licensing",
-        "type": "download",
-        "version": "0.2.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.LinuxMonitor/8/artifact/dist/ZenPacks.zenoss.LinuxMonitor-2.0.3-py2.7.egg",
-        "git_ref": "2.0.3",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.LinuxMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.LinuxMonitor",
-        "type": "download",
-        "version": "2.0.3"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.Microsoft.Windows/51/artifact/dist/ZenPacks.zenoss.Microsoft.Windows-2.6.1-py2.7.egg",
-        "git_ref": "2.6.1",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.Microsoft.Windows.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.Microsoft.Windows",
-        "type": "download",
-        "version": "2.6.1"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.MySqlMonitor/13/artifact/dist/ZenPacks.zenoss.MySqlMonitor-3.0.7-py2.7.egg",
-        "git_ref": "3.0.7",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.MySqlMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.MySqlMonitor",
-        "type": "download",
-        "version": "3.0.7"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.NetAppMonitor/14/artifact/dist/ZenPacks.zenoss.NetAppMonitor-3.3.1-py2.7.egg",
-        "git_ref": "3.3.1",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.NetAppMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.NetAppMonitor",
-        "type": "download",
-        "version": "3.3.1"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.NetScaler/9/artifact/dist/ZenPacks.zenoss.NetScaler-1.0.6-py2.7.egg",
-        "git_ref": "1.0.6",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.NetScaler.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.NetScaler",
-        "type": "download",
-        "version": "1.0.6"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.NetScreenMonitor/1/artifact/dist/ZenPacks.zenoss.NetScreenMonitor-2.2.0-py2.7.egg",
-        "git_ref": "2.2.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.NetScreenMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.NetScreenMonitor",
-        "type": "download",
-        "version": "2.2.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.NortelMonitor/1/artifact/dist/ZenPacks.zenoss.NortelMonitor-2.0.2-py2.7.egg",
-        "git_ref": "2.0.2",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.NortelMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.NortelMonitor",
-        "type": "download",
-        "version": "2.0.2"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.NtpMonitor/4/artifact/dist/ZenPacks.zenoss.NtpMonitor-2.2.2-py2.7.egg",
-        "git_ref": "2.2.2",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.NtpMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.NtpMonitor",
-        "type": "download",
-        "version": "2.2.2"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.PredictiveThreshold/4/artifact/dist/ZenPacks.zenoss.PredictiveThreshold-1.1.1-py2.7.egg",
-        "git_ref": "1.1.1",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.PredictiveThreshold.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.PredictiveThreshold",
-        "type": "download",
-        "version": "1.1.1"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.PropertyMonitor/4/artifact/dist/ZenPacks.zenoss.PropertyMonitor-1.1.0-py2.7.egg",
-        "git_ref": "1.1.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.PropertyMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.PropertyMonitor",
-        "type": "download",
-        "version": "1.1.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.PythonCollector/28/artifact/dist/ZenPacks.zenoss.PythonCollector-1.8.1-py2.7.egg",
-        "git_ref": "1.8.1",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.PythonCollector.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.PythonCollector",
-        "type": "download",
-        "version": "1.8.1"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.SolarisMonitor/10/artifact/dist/ZenPacks.zenoss.SolarisMonitor-2.4.1-py2.7.egg",
-        "git_ref": "2.4.1",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.SolarisMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.SolarisMonitor",
-        "type": "download",
-        "version": "2.4.1"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.StorageBase/8/artifact/dist/ZenPacks.zenoss.StorageBase-1.4.1-py2.7.egg",
-        "git_ref": "1.4.1",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.StorageBase.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.StorageBase",
-        "type": "download",
-        "version": "1.4.1"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.SupportBundle/4/artifact/dist/ZenPacks.zenoss.SupportBundle-1.1.0-py2.7.egg",
-        "git_ref": "1.1.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.SupportBundle.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.SupportBundle",
-        "type": "download",
-        "version": "1.1.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.TomcatMonitor/1/artifact/dist/ZenPacks.zenoss.TomcatMonitor-2.3.0-py2.7.egg",
-        "git_ref": "2.3.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.TomcatMonitor.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.TomcatMonitor",
-        "type": "download",
-        "version": "2.3.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.WBEM/3/artifact/dist/ZenPacks.zenoss.WBEM-1.0.3-py2.7.egg",
-        "git_ref": "1.0.3",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.WBEM.git",
-        "name": "ZenPacks.zenoss.WBEM",
-        "type": "download",
-        "version": "1.0.3"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.WebLogicMonitor/2/artifact/dist/ZenPacks.zenoss.WebLogicMonitor-2.2.3-py2.7.egg",
-        "git_ref": "2.2.3",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.WebLogicMonitor.git",
-        "name": "ZenPacks.zenoss.WebLogicMonitor",
-        "type": "download",
-        "version": "2.2.3"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.WebsphereMonitor/2/artifact/dist/ZenPacks.zenoss.WebsphereMonitor-1.2.2-py2.7.egg",
-        "git_ref": "1.2.2",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.WebsphereMonitor.git",
-        "name": "ZenPacks.zenoss.WebsphereMonitor",
-        "type": "download",
-        "version": "1.2.2"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenDeviceACL/2/artifact/dist/ZenPacks.zenoss.ZenDeviceACL-2.2.0-py2.7.egg",
-        "git_ref": "2.2.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.ZenDeviceACL.git",
-        "name": "ZenPacks.zenoss.ZenDeviceACL",
-        "type": "download",
-        "version": "2.2.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenJMX/7/artifact/dist/ZenPacks.zenoss.ZenJMX-3.12.1-py2.7.egg",
-        "git_ref": "3.12.1",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.ZenJMX.git",
-        "name": "ZenPacks.zenoss.ZenJMX",
-        "type": "download",
-        "version": "3.12.1"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenMail/2/artifact/dist/ZenPacks.zenoss.ZenMail-5.1.0-py2.7.egg",
-        "git_ref": "5.1.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.ZenMail.git",
-        "name": "ZenPacks.zenoss.ZenMail",
-        "type": "download",
-        "version": "5.1.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenMailTx/4/artifact/dist/ZenPacks.zenoss.ZenMailTx-2.6.0-py2.7.egg",
-        "git_ref": "2.6.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.ZenMailTx.git",
-        "name": "ZenPacks.zenoss.ZenMailTx",
-        "type": "download",
-        "version": "2.6.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenOperatorRole/2/artifact/dist/ZenPacks.zenoss.ZenOperatorRole-2.1.0-py2.7.egg",
-        "git_ref": "2.1.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.ZenOperatorRole.git",
-        "name": "ZenPacks.zenoss.ZenOperatorRole",
-        "type": "download",
-        "version": "2.1.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenSQLTx/5/artifact/dist/ZenPacks.zenoss.ZenSQLTx-2.6.3-py2.7-linux-x86_64.egg",
-        "git_ref": "2.6.3",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.ZenSQLTx.git",
-        "name": "ZenPacks.zenoss.ZenSQLTx",
-        "type": "download",
-        "version": "2.6.3"
-    },
-    {
-        "URL":  "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.ZenWebTx/9/artifact/dist/ZenPacks.zenoss.ZenWebTx-3.0.0-py2.7.egg",
-        "git_ref": "3.0.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.ZenWebTx.git",
-        "name": "ZenPacks.zenoss.ZenWebTx",
-        "type": "download",
-        "version": "3.0.0"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.vCloud/6/artifact/dist/ZenPacks.zenoss.vCloud-1.4.9-py2.7.egg",
-        "git_ref": "1.4.9",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.vCloud.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.vCloud",
-        "type": "download",
-        "version": "1.4.9"
-    },
-    {
-        "URL": "http://jenkins.zenosslabs.com/job/master-ZenPacks.zenoss.vSphere/22/artifact/dist/ZenPacks.zenoss.vSphere-3.4.1-py2.7.egg",
-        "git_ref": "3.4.0",
-        "git_repo": "https://github.com/zenoss/ZenPacks.zenoss.vSphere.git",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.vSphere",
-        "type": "download",
-        "version": "3.4.0"
+        "type": "zenpack"
+    },{
+        "name": "ZenPacks.zenoss.WBEM",
+        "type": "zenpack"
+    },{
+        "name": "ZenPacks.zenoss.WebLogicMonitor",
+        "type": "zenpack"
+    },{
+        "name": "ZenPacks.zenoss.WebsphereMonitor",
+        "type": "zenpack"
+    },{
+        "name": "ZenPacks.zenoss.ZenDeviceACL",
+        "type": "zenpack"
+    },{
+        "name": "ZenPacks.zenoss.ZenJMX",
+        "type": "zenpack"
+    },{
+        "name": "ZenPacks.zenoss.ZenMail",
+        "type": "zenpack"
+    },{
+        "name": "ZenPacks.zenoss.ZenMailTx",
+        "type": "zenpack"
+    },{
+        "name": "ZenPacks.zenoss.ZenOperatorRole",
+        "type": "zenpack"
+    },{
+        "name": "ZenPacks.zenoss.ZenSQLTx",
+        "type": "zenpack"
+    },{
+        "name": "ZenPacks.zenoss.ZenWebTx",
+        "type": "zenpack"
     }
 ]


### PR DESCRIPTION
Updated zenpack_versions.json to use the new "zenpack" downloader type
for all ZenPacks. Given that this is the develop branch, I went with a
configuration that will use the latest release build for all ZenPacks
except for CatalogService which will use the latest pre-release build.

See the docstring for the zenpackDownload() method in
artifact_download.py for a full description of the "zenpack" download
type's capabilities.