### PR TITLE
Initial creation of devimg

### DIFF
--- a/devimg/build-devbase.sh
+++ b/devimg/build-devbase.sh
@@ -9,9 +9,7 @@
 # by this script. For instance, if you want to build devimg with a custom version
 # zenoss-centos-base, you could run something like:
 #
-# FROM_IMAGE=zenoss-centos-base:1.3.9-dev BASE_TAG=zendev/devimg:metis ./build-devbase.sh
-#
-# And the value of FROM_IMAGE will be inherited by the make execution
+# BASE_TAG=zendev/devimg:metis ./build-devbase.sh
 #
 if [ -z "${BASE_TAG}" ]
 then

--- a/devimg/build-devbase.sh
+++ b/devimg/build-devbase.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# build-devbase.sh - build the image that will serve as the basis for zendev/devimg.
+#
+# Required Arguments (specified as environment variables):
+# BASE_TAG - the full docker tag of image to build
+#
+# Any other environment variables will be inherited by the make which is invoked
+# by this script. For instance, if you want to build devimg with a custom version
+# zenoss-centos-base, you could run something like:
+#
+# FROM_IMAGE=zenoss-centos-base:1.3.9-dev BASE_TAG=zendev/devimg:metis ./build-devbase.sh
+#
+# And the value of FROM_IMAGE will be inherited by the make execution
+#
+if [ -z "${BASE_TAG}" ]
+then
+	echo "ERROR: Missing required argument - BASE_TAG"
+	exit 1
+fi
+
+#
+# if the target image exists, don't rebuild it.
+#
+# Normally, native makefile syntax is used for these kinds of checks, but
+# in the case of docker images, it's more straightfoward to implement here.
+#
+IMAGE_EXISTS=`docker images | awk '{print $1":"$2}' | grep ${BASE_TAG} 2>/dev/null`
+if [ ! -z "${IMAGE_EXISTS}" ]
+then
+	echo "Skipping build-devimg because ${BASE_TAG} exists already"
+	exit 0
+fi
+
+# Get the uid/gid of the current user so that we can change the zenoss user in the
+# the container to match the UID/GID of the current user.
+CURRENT_UID=`id -u`
+CURRENT_GID=`id -g`
+
+set -e
+set -x
+
+cd ../product-base
+TAG=${BASE_TAG} INSTALL_OPTIONS="--change-uid ${CURRENT_UID}:${CURRENT_GID}" make build-devimg

--- a/devimg/build.sh
+++ b/devimg/build.sh
@@ -2,10 +2,13 @@
 #
 # build.sh - build zendev/devimg.
 #
-# This script assumes that zendev/devimg already exists as an incomplete image;
-# see build-devbase.sh. This script then runs create_zenoss.sh with several
-# key directories in the image bind-mounted to source directories in the
-# developer's machine.
+# This script assumes that zendev/devimg-base already exists; see build-devbase.sh.
+# This script runs create_devimg.sh in zendev/devimg-base with several key
+# directories in the image bind-mounted to source directories in the developer's
+# local sandbox.  The create_devimg.sh script creates zenoss, optionally link
+# installs zenpacks and setups some other component links. After
+# create_devimg.sh completes, this script commits the resultant container as a
+# new zendev/devimg image.
 #
 # Required Arguments (specified as environment variables):
 # BASE_TAG    - the tag of image to start from (e.g. zendev/devimg-base:<envName>)
@@ -61,9 +64,6 @@ docker run \
 	-v ${ZENDEV_ROOT}/zenhome:/opt/zenoss \
 	-v ${ZENDEV_ROOT}/var_zenoss:/var/zenoss \
 	-v ${SRCROOT}:/mnt/src \
-	-v ${PRODBIN_SRC}/Products:/opt/zenoss/Products \
-	-v ${PRODBIN_SRC}/devimg:/opt/zenoss/devimg \
-	-v ${ZENPACK_SRC}:/opt/zenoss/packs \
 	-t ${BASE_TAG} \
 	/opt/zenoss/install_scripts/create_devimg.sh
 

--- a/devimg/build.sh
+++ b/devimg/build.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# build.sh - build zendev/devimg.
+#
+# This script assumes that zendev/devimg already exists as an incomplete image;
+# see build-devbase.sh. This script then runs create_zenoss.sh with several
+# key directories in the image bind-mounted to source directories in the
+# developer's machine.
+#
+# Required Arguments (specified as environment variables):
+# BASE_TAG    - the tag of image to start from (e.g. zendev/devimg-base:<envName>)
+# TAG         - the full docker tag of image to build (e.g. zendev/devimg:<envName>)
+# ZENDEV_ROOT - see the description in makefile
+# SRCROOT     - see the description in makefile
+# PRODBIN_SRC - see the description in makefile
+# ZENPACK_SRC - see the description in makefile
+
+if [ -z "${BASE_TAG}" ]
+then
+	echo "ERROR: Missing required argument - BASE_TAG"
+	exit 1
+elif [ -z "${TAG}" ]
+then
+	echo "ERROR: Missing required argument - TAG"
+	exit 1
+elif [ -z "${ZENDEV_ROOT}" ]
+then
+	echo "ERROR: Missing required argument - ZENDEV_ROOT"
+	exit 1
+elif [ -z "${SRCROOT}" ]
+then
+	echo "ERROR: Missing required argument - SRCROOT"
+elif [ -z "${PRODBIN_SRC}" ]
+then
+	echo "ERROR: Missing required argument - PRODBIN_SRC"
+	exit 1
+elif [ -z "${ZENPACK_SRC}" ]
+then
+	echo "ERROR: Missing required argument - ZENPACK_SRC"
+	exit 1
+fi
+
+echo "Initializing Zenoss and installing Zenpacks ..."
+echo "   ZENHOME=${ZENDEV_ROOT}/zenhome"
+echo "   VAR_ZENOSS=${ZENDEV_ROOT}/var_zenoss"
+echo "   SRCROOT=${SRCROOT}"
+echo "   PRODBIN_SRC=${PRODBIN_SRC}"
+echo "   ZENPACK_SRC=${ZENPACK_SRC}"
+
+CONTAINER_ID_FILE=containerID.txt
+rm -f ${CONTAINER_ID_FILE}
+
+set -e
+set -x
+
+# Run create_zenoss, record the container id and CONTAINER_ID_FILE and leave
+# the image running so that we can commit the changes
+#
+docker run \
+	--cidfile ${CONTAINER_ID_FILE} \
+	-v ${ZENDEV_ROOT}/zenhome:/opt/zenoss \
+	-v ${ZENDEV_ROOT}/var_zenoss:/var/zenoss \
+	-v ${SRCROOT}:/mnt/src \
+	-v ${PRODBIN_SRC}/Products:/opt/zenoss/Products \
+	-v ${PRODBIN_SRC}/devimg:/opt/zenoss/devimg \
+	-v ${ZENPACK_SRC}:/opt/zenoss/packs \
+	-t ${BASE_TAG} \
+	/opt/zenoss/install_scripts/create_devimg.sh
+
+echo "Committing all of the changes to ${TAG}"
+CONTAINER_ID=`cat ${CONTAINER_ID_FILE}`
+docker commit ${CONTAINER_ID} ${TAG}
+
+docker rm -f ${CONTAINER_ID}
+rm -f ${CONTAINER_ID_FILE}

--- a/devimg/makefile
+++ b/devimg/makefile
@@ -41,8 +41,6 @@
 #                 The file name must be "zenpacks.json".
 #                 For example, ZENPACK_FILE=../core/zenpacks.json is equivalent
 #                 to TARGET_PRODUCT=core
-# FROM_IMAGE      Specifies an alternate copy of zenoss-centos-base to use as
-#                 the basis for zendev/devimg-base
 # PRODBIN_SRC     the full directory path to the developers local checkout of zenoss-prodbin
 # ZENPACK_SRC     the full directory path to the parent directory containing all
 #                 of the ZenPacks checked out locally by the developer
@@ -53,7 +51,6 @@ DEV_ENV ?= metis
 TAG = zendev/$(IMAGENAME):$(DEV_ENV)
 BASE_TAG = zendev/$(IMAGENAME)-base:$(DEV_ENV)
 
-FROM_IMAGE ?= zenoss-centos-base:1.2.5
 CONTAINER_ZENHOME=/opt/zenoss
 
 .PHONY: clean build
@@ -117,7 +114,7 @@ clean:
 
 build-devbase:
 	@echo "Building $(BASE_TAG) ..."
-	FROM_IMAGE=$(FROM_IMAGE) BASE_TAG=$(BASE_TAG) ./build-devbase.sh
+	BASE_TAG=$(BASE_TAG) ./build-devbase.sh
 
 # Initialize our local ZENHOME using the contents from the initial devimg
 initialize-zenhome: make-dirs

--- a/devimg/makefile
+++ b/devimg/makefile
@@ -18,6 +18,7 @@
 # zenoss user/group remapped to the uid/gid of the developer creating devimg.
 #
 # zendev/devimg is built just like the standard product images, except:
+#   - zenoss-prodbin/Products is mounted/linked into ZENHOME/Products
 #   - the ZenPacks are link-installed with soft-links
 #   - Java apps are soft-linked from ZENHOME/lib/<appDir> back to their
 #     source directory
@@ -41,9 +42,6 @@
 #                 The file name must be "zenpacks.json".
 #                 For example, ZENPACK_FILE=../core/zenpacks.json is equivalent
 #                 to TARGET_PRODUCT=core
-# PRODBIN_SRC     the full directory path to the developers local checkout of zenoss-prodbin
-# ZENPACK_SRC     the full directory path to the parent directory containing all
-#                 of the ZenPacks checked out locally by the developer
 #
 include ../versions.mk
 IMAGENAME  = devimg
@@ -66,7 +64,7 @@ endif
 # Note that this list includes the directories used as mount points. We create
 # need to create those directories here so they are owned by the current user
 # (otherwise, they will be owned by root when docker creates them).
-make-dirs: verifyInputs $(ZENDEV_ROOT)/zenhome $(ZENDEV_ROOT)/zenhome/devimg $(ZENDEV_ROOT)/zenhome/packs $(ZENDEV_ROOT)/var_zenoss
+make-dirs: verifyInputs $(ZENDEV_ROOT)/zenhome  $(ZENDEV_ROOT)/var_zenoss
 
 $(ZENDEV_ROOT)/%:
 	mkdir -p $@
@@ -85,8 +83,8 @@ endif
 	@echo "ZENPACK_FILE='$(ZENPACK_FILE)'"
 	@if [ ! -f $(ZENPACK_FILE) ]; then echo "ZENPACK_FILE=$(ZENPACK_FILE) does not exist"; exit 1; fi
 
-ZENPACK_SRC ?= $(SRCROOT)
-PRODBIN_SRC ?= $(SRCROOT)/zenoss-prodbin
+ZENPACK_SRC = $(SRCROOT)
+PRODBIN_SRC = $(SRCROOT)/zenoss-prodbin
 
 #
 # four major steps to creating the devimg:
@@ -94,8 +92,8 @@ PRODBIN_SRC ?= $(SRCROOT)/zenoss-prodbin
 #    built on the ".devtools" version of zenoss-centos-base.
 # 2. initialize-zenhome - Copies the contents of /opt/zenoss/* from the image
 #    into our local ZENHOME directory
-# 3. add-zenpack-file - Adds the zenpacks to the image based on a file
-#    containing a list of zenpacks (optional)
+# 3. add-zenpack-file - Adds a 'zenpack.json' file to ZENHOME within the image
+#    such that the last step can use that file to install zenpacks (optional)
 # 4. build.sh - Initialize zenoss, link-install zenpacks (if any), and setup other
 #    linkages like Java apps, zenoss-protocols, etc.
 #
@@ -122,7 +120,10 @@ initialize-zenhome: make-dirs
 	docker run --rm \
 		-v $(ZENDEV_ROOT)/zenhome:/mnt/local-zenhome \
 		-t $(BASE_TAG) \
-		bash -c "rm -rf /mnt/local-zenhome/*; cp -rp $(CONTAINER_ZENHOME)/* /mnt/local-zenhome"
+		bash -c "/opt/zenoss/install_scripts/init_devimg_zenhome.sh /mnt/local-zenhome"
+	ln -s /mnt/src/zenoss-prodbin/Products $(ZENDEV_ROOT)/zenhome/Products
+	ln -s /mnt/src/zenoss-prodbin/devimg $(ZENDEV_ROOT)/zenhome/devimg
+	ln -s /mnt/src $(ZENDEV_ROOT)/zenhome/packs
 
 add-zenpack-file:
 	@if [ -z "$(ZENPACK_FILE)" ]; then \

--- a/devimg/makefile
+++ b/devimg/makefile
@@ -1,0 +1,137 @@
+#
+# Makefile to build zendev/devimg
+#
+# At high level, the image "stack" for zendev/devimg looks like:
+#
+# zendev/devimg:<envName>
+#     ^
+#     |
+# zendev/devimg-base:<envName>
+#     ^
+#     |
+# zenoss/zenoss-centos-base:<ver>.devtools
+#
+# zenoss-centos-base:<ver>.devtools is a variant of zenoss-centos-base that
+# contains development tools like the JDK, Maven, make and GO.
+#
+# devimg-base:<envName> is a variant of product-base with the uid/gid of the
+# zenoss user/group remapped to the uid/gid of the developer creating devimg.
+#
+# zendev/devimg is built just like the standard product images, except:
+#   - the ZenPacks are link-installed with soft-links
+#   - Java apps are soft-linked from ZENHOME/lib/<appDir> back to their
+#     source directory
+#
+# This file REQUIRES the following input variables.  Note that all of these
+# except TARGET_PRODUCT are defined in ../versions.mk
+#
+# ZENDEV_ROOT     the parent directory created by zendev which contains the
+#                 zenhome and var_zenoss subdirectories. In other words, the
+#                 developer's ZENHOME=$ZENDEV_ROOT/zenhome.
+# SRCROOT         the root directory of the zendev's environment source code.
+#                 Typically, something like $HOME/src/<envName>/src
+#
+# The following input variables are OPTIONAL. They may be set in various special
+# circumstances, but in most case only TARGET_PRODUCT is specified
+#
+# TARGET_PRODUCT  the name of the product to use in order to decide which zenpacks
+#                 to install into the devimg; e.g. 'core', 'resmgr', etc
+# ZENPACK_FILE    An alternative to TARGET_PRODUCT - the path to a "zenpacks.json"
+#                 file containing a custom list of zenpacks to install into devimg.
+#                 The file name must be "zenpacks.json".
+#                 For example, ZENPACK_FILE=../core/zenpacks.json is equivalent
+#                 to TARGET_PRODUCT=core
+# FROM_IMAGE      Specifies an alternate copy of zenoss-centos-base to use as
+#                 the basis for zendev/devimg-base
+# PRODBIN_SRC     the full directory path to the developers local checkout of zenoss-prodbin
+# ZENPACK_SRC     the full directory path to the parent directory containing all
+#                 of the ZenPacks checked out locally by the developer
+#
+include ../versions.mk
+IMAGENAME  = devimg
+DEV_ENV ?= metis
+TAG = zendev/$(IMAGENAME):$(DEV_ENV)
+BASE_TAG = zendev/$(IMAGENAME)-base:$(DEV_ENV)
+
+FROM_IMAGE ?= zenoss-centos-base:1.2.5
+CONTAINER_ZENHOME=/opt/zenoss
+
+.PHONY: clean build
+
+verifyInputs:
+ifndef ZENDEV_ROOT
+	$(error ZENDEV_ROOT is not set)
+endif
+ifndef SRCROOT
+	$(error SRCROOT is not set)
+endif
+
+# Note that this list includes the directories used as mount points. We create
+# need to create those directories here so they are owned by the current user
+# (otherwise, they will be owned by root when docker creates them).
+make-dirs: verifyInputs $(ZENDEV_ROOT)/zenhome $(ZENDEV_ROOT)/zenhome/devimg $(ZENDEV_ROOT)/zenhome/packs $(ZENDEV_ROOT)/var_zenoss
+
+$(ZENDEV_ROOT)/%:
+	mkdir -p $@
+
+select-zenpacks: verifyInputs
+ifdef TARGET_PRODUCT
+	@echo "Using TARGET_PRODUCT='$(TARGET_PRODUCT)'"
+	$(eval ZENPACK_FILE=../$(TARGET_PRODUCT)/zenpacks.json)
+else
+ifdef ZENPACK_FILE
+	@echo "Using ZENPACK_FILE='$(ZENPACK_FILE)'"
+else
+	@echo "Building without zenpacks"
+endif
+endif
+	@echo "ZENPACK_FILE='$(ZENPACK_FILE)'"
+	@if [ ! -f $(ZENPACK_FILE) ]; then echo "ZENPACK_FILE=$(ZENPACK_FILE) does not exist"; exit 1; fi
+
+ZENPACK_SRC ?= $(SRCROOT)
+PRODBIN_SRC ?= $(SRCROOT)/zenoss-prodbin
+
+#
+# four major steps to creating the devimg:
+# 1. build-devbase - Create a devimg-base image starting the same as product-base, but
+#    built on the ".devtools" version of zenoss-centos-base.
+# 2. initialize-zenhome - Copies the contents of /opt/zenoss/* from the image
+#    into our local ZENHOME directory
+# 3. add-zenpack-file - Adds the zenpacks to the image based on a file
+#    containing a list of zenpacks (optional)
+# 4. build.sh - Initialize zenoss, link-install zenpacks (if any), and setup other
+#    linkages like Java apps, zenoss-protocols, etc.
+#
+build: make-dirs select-zenpacks build-devbase initialize-zenhome add-zenpack-file
+	BASE_TAG=$(BASE_TAG) \
+	TAG=$(TAG) \
+	ZENDEV_ROOT=$(ZENDEV_ROOT) \
+	PRODBIN_SRC=$(PRODBIN_SRC) \
+	ZENPACK_SRC=$(ZENPACK_SRC) \
+	./build.sh
+
+clean:
+	-cd ../product-base;TAG=$(BASE_TAG) make clean
+	-docker rmi -f $(TAG)
+	rm -rf $(ZENDEV_ROOT)/zenhome/* $(ZENDEV_ROOT)/var_zenoss/*
+
+build-devbase:
+	@echo "Building $(BASE_TAG) ..."
+	FROM_IMAGE=$(FROM_IMAGE) BASE_TAG=$(BASE_TAG) ./build-devbase.sh
+
+# Initialize our local ZENHOME using the contents from the initial devimg
+initialize-zenhome: make-dirs
+	@echo "Initializing ZENHOME from container contents..."
+	docker run --rm \
+		-v $(ZENDEV_ROOT)/zenhome:/mnt/local-zenhome \
+		-t $(BASE_TAG) \
+		bash -c "rm -rf /mnt/local-zenhome/*; cp -rp $(CONTAINER_ZENHOME)/* /mnt/local-zenhome"
+
+add-zenpack-file:
+	@if [ -z "$(ZENPACK_FILE)" ]; then \
+		echo "ZENPACK_FILE is empty; not installing any zenpacks"; \
+	else \
+		echo "Using the zenpacks defined by $(ZENPACK_FILE)"; \
+		cp $(ZENPACK_FILE) $(ZENDEV_ROOT)/zenhome/install_scripts; \
+	fi
+	@echo "No downloaded zenpacks; all zenpacks link-installed from source" > $(ZENDEV_ROOT)/zenhome/log/zenpacks_artifact.log

--- a/product-base/Dockerfile.in
+++ b/product-base/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM zenoss/zenoss-centos-base:1.2.4
+FROM zenoss/%FROM_IMAGE%
 
 # maintener is redundant since base image is ours as well
 #MAINTAINER Zenoss <dev@zenoss.com>

--- a/product-base/Dockerfile.in
+++ b/product-base/Dockerfile.in
@@ -12,4 +12,4 @@ ADD hubpasswd /opt/zenoss/etc/
 
 ADD install_scripts component_info /opt/zenoss/install_scripts/
 
-RUN /opt/zenoss/install_scripts/zenoss_component_install.sh
+RUN /opt/zenoss/install_scripts/zenoss_component_install.sh %INSTALL_OPTIONS%

--- a/product-base/Dockerfile.in
+++ b/product-base/Dockerfile.in
@@ -7,9 +7,9 @@ ENV ZENHOME=/opt/zenoss
 
 ADD %SHORT_VERSION%.x /root/%SHORT_VERSION%.x
 
+# TODO: fix this. The hubpasswd file should be in the service definition
+ADD hubpasswd /opt/zenoss/etc/
+
 ADD install_scripts component_info /opt/zenoss/install_scripts/
 
 RUN /opt/zenoss/install_scripts/zenoss_component_install.sh
-
-# TODO: fix this. The hubpasswd file should be in the service definition
-ADD hubpasswd /opt/zenoss/etc/

--- a/product-base/install_scripts/create_devimg.sh
+++ b/product-base/install_scripts/create_devimg.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+if [ -z "${SRCROOT}" ]
+then
+    SRCROOT=/mnt/src
+fi
+
+if [ ! -d "${SRCROOT}" ]
+then
+    echo "ERROR: SRCROOT=${SRCROOT} does not exist"
+    exit 1
+fi
+
+set -e
+set -x
+
+echo "Starting create_devimg ..."
+export BUILD_DEVIMG=1
+/opt/zenoss/install_scripts/create_zenoss.sh
+echo "Finished create_zenoss.sh"
+
+echo "Link in Java apps"
+rm -rf ${ZENHOME}/lib/central-query
+ln -s ${SRCROOT}/query ${ZENHOME}/lib/central-query
+chown zenoss:zenoss ${ZENHOME}/lib/central-query
+
+rm -rf ${ZENHOME}/lib/metric-consumer-app
+ln -s ${SRCROOT}/zenoss.metric.consumer/metric-consumer-app ${ZENHOME}/lib/metric-consumer-app
+chown zenoss:zenoss ${ZENHOME}/lib/metric-consumer-app
+
+echo "Install zenoss-protocols in development mode"
+su - zenoss -c "pip uninstall -y zenoss.protocols"
+su - zenoss -c "pip install -e ${SRCROOT}/zenoss-protocols/python"
+
+echo "Install zenwipe"
+cp /opt/zenoss/devimg/zenwipe.sh /opt/zenoss/bin/zenwipe.sh
+chown zenoss:zenoss /opt/zenoss/bin/zenwipe.sh
+chmod 754 /opt/zenoss/bin/zenwipe.sh
+
+# TODO
+# include zep

--- a/product-base/install_scripts/create_zenoss.sh
+++ b/product-base/install_scripts/create_zenoss.sh
@@ -5,7 +5,7 @@
 . ${ZENHOME}/install_scripts/install_lib.sh
 
 set -e
-set -x 
+set -x
 
 
 start_requirements
@@ -18,7 +18,6 @@ sleep 5
 
 echo "Running zenoss_init"
 ${ZENHOME}/install_scripts/zenoss_init.sh
-
 
 echo "Cleaning up dmd.uuid"
 echo "dmd.uuid = None" > /tmp/cleanuuid.zendmd
@@ -41,9 +40,6 @@ sleep 10
 echo "Cleaning up mysql data..."
 rm /var/lib/mysql/ib_logfile0
 rm /var/lib/mysql/ib_logfile1
-
-echo "TODO REMOVE THIS AFTER PRODBIN IS UPDATED TO FILTER OUT MIGRATE TESTS"
-rm -rf ${ZENHOME}/Products/ZenModel/migrate/tests
 
 echo "Cleaning up after install..."
 find ${ZENHOME} -name \*.py[co] -delete

--- a/product-base/install_scripts/init_devimg_zenhome.sh
+++ b/product-base/install_scripts/init_devimg_zenhome.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Initialize zenhome for devimg by copying the container's ZENHOME contents
+#   to a mount point outside of the container which points to the current
+#   user's ZENHOME on the host OS.
+#
+if [ -z "${1}" ]
+then
+	echo "ERROR: missing required argument for target mount point"
+	exit 1
+elif [ ! -d "${1}" ]
+then
+	echo "ERROR: target mount point '${1}' not found"
+	exit 1
+fi
+
+if [ -z "${ZENHOME}" ]
+then
+	echo "ERROR: ZENHOME not defined"
+	exit 1
+fi
+
+TARGET_MOUNT=${1}
+
+# Delete anything that's already in the mounted volume. This step executes
+# in the container as root so we can remove any root-owned files that get
+# created in the developer's local ZENHOME.
+rm -rf ${TARGET_MOUNT}/*
+
+# Copy out everything in ZENHOME except Products, devimg and packs.
+# These directories will be soft-linked in host OS.
+find ${ZENHOME} -maxdepth 1 |\
+	egrep -v '/Products|/devimg|/packs' |\
+	xargs --no-run-if-empty cp -rp -t ${TARGET_MOUNT}

--- a/product-base/install_scripts/zenoss_component_install.sh
+++ b/product-base/install_scripts/zenoss_component_install.sh
@@ -5,7 +5,8 @@ set -x
 
 mkdir -p ${ZENHOME}/log/
 
-#Files added via docker will be owned by root, set to zenoss
+# Files added via docker will be owned by root, set to zenoss to start to avoid conflicts
+# as we unpack components into ZENHOME
 chown -Rf zenoss:zenoss ${ZENHOME}/*
 
 
@@ -83,9 +84,18 @@ su - zenoss -c "tar -C ${ZENHOME} -xzvf /tmp/redis-mon*"
 artifactDownload "zproxy"
 su - zenoss -c "tar --strip-components=2 -C ${ZENHOME} -xzvf /tmp/zproxy*"
 
-
+# Install the service migration SDK
 artifactDownload "servicemigration"
 su - zenoss -c "pip install  --use-wheel --no-index  /tmp/servicemigration*"
+
+# Some components have files which are read-only by zenoss, so we need to
+# open up the permissions to allow read/write for the group and read for
+# all others.  We need to make this minimal setting here to facilitate
+# creation of a devimg.
+#
+# Note that the final arbitration of permissions will be done by zenoss_init.sh
+# when the actual product image is created.
+chmod -R g+rw,o+r,+X ${ZENHOME}/*
 
 # TODO add upgrade templates to /root  - probably done in core/rm image builds
 

--- a/product-base/install_scripts/zenoss_component_install.sh
+++ b/product-base/install_scripts/zenoss_component_install.sh
@@ -3,11 +3,37 @@
 set -e
 set -x
 
+if [ $# -ne 0 -a $# -ne 2 ]
+then
+	echo "ERROR: $# is an invalid number of arguments; only 0 or 2 arguments are allowed"
+	exit 1
+elif [ $# -eq 2 ]
+then
+	if [ "$1" != "--change-uid" ]
+	then
+		echo "ERROR: invalid option '$1'; only --change-uid allowed"
+		exit 1
+	fi
+
+	# This section is typically used for devimg's to apply the uid/gid of the
+	# current user to the zenoss user/group in the image.
+	NEW_UID=`echo $2 | cut -d: -f1`
+	NEW_GID=`echo $2 | cut -d: -f1`
+	echo "Changing zenoss user/group ids to ${NEW_UID}:${NEW_GID}"
+
+	groupmod --gid ${NEW_GID} zenoss
+	usermod --uid ${NEW_UID} --gid ${NEW_GID} zenoss
+
+	# Fix up ownership for zenoss-owned files outside of ZENHOME
+	chown zenoss:zenoss /var/spool/mail/zenoss
+	chown -Rf zenoss:zenoss /home/zenoss
+fi
+
 mkdir -p ${ZENHOME}/log/
 
 # Files added via docker will be owned by root, set to zenoss to start to avoid conflicts
 # as we unpack components into ZENHOME
-chown -Rf zenoss:zenoss ${ZENHOME}/*
+chown -Rf zenoss:zenoss ${ZENHOME}
 
 
 function artifactDownload

--- a/product-base/install_scripts/zenoss_init.sh
+++ b/product-base/install_scripts/zenoss_init.sh
@@ -8,12 +8,12 @@
 # Note: it is run by root
 #
 ##############################################################################
-# 
+#
 # Copyright (C) Zenoss, Inc. 2007, all rights reserved.
-# 
+#
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
-# 
+#
 ##############################################################################
 
 set -e
@@ -68,6 +68,10 @@ run_zenbuild
 echo "Add default system user..."
 ${ZENHOME}/bin/zendmd --script ${ZENHOME}/bin/addSystemUser.py
 
+# These directories need to be setup prior to zenpack install to facilitate
+# link installs for zendev/devimg
+ensure_dfs_dirs
+
 echo "Checking for zenpack file ${ZENHOME}/install_scripts/zenpacks.json ..."
 if [ -f "${ZENHOME}/install_scripts/zenpacks.json" ]; then
     echo "Starting zeneventserver for zenpack install..."
@@ -76,12 +80,14 @@ if [ -f "${ZENHOME}/install_scripts/zenpacks.json" ]; then
     # run zp install
     #TODO the output from zp_install.py and the zenpack install subprocesses it creates comes out of order, need to fix
     echo "Installing zenpacks..."
-    su - zenoss  -c "${ZENHOME}/install_scripts/zp_install.py ${ZENHOME}/install_scripts/zenpacks.json ${ZENHOME}/packs"
+    if [ -z "${BUILD_DEVIMG}" ]
+    then
+       LINK_INSTALL=""
+    else
+       LINK_INSTALL="--link"
+    fi
+    su - zenoss  -c "${ZENHOME}/install_scripts/zp_install.py ${ZENHOME}/install_scripts/zenpacks.json ${ZENHOME}/packs ${LINK_INSTALL}"
 
     echo "Stopping zeneventserver..."
     su - zenoss  -c "${ZENHOME}/bin/zeneventserver stop"
 fi
-
-
-ensure_dfs_dirs
-

--- a/product-base/install_scripts/zp_install.py
+++ b/product-base/install_scripts/zp_install.py
@@ -20,7 +20,10 @@ def main(args):
             zpFile = os.path.join(args.zpDir, zpFileName[0])
             print "Installing zenpack: %s %s" % (zpName, zpFile)
             sys.stdout.flush()
-            subprocess.check_call(['zenpack', '--install', zpFile])
+            cmd = ['zenpack', '--install', zpFile]
+            if args.link:
+                cmd.append('--link')
+            subprocess.check_call(cmd)
 
 
 if __name__ == '__main__':
@@ -29,5 +32,7 @@ if __name__ == '__main__':
                         help='json file with list of zenpacks to be installed')
     parser.add_argument('zpDir', type=str, nargs="?", default=".",
                         help='directory where zenpacks are, defaults to pwd')
+    parser.add_argument('--link', action="store_true",
+                        help='link-install the zenpacks')
     args = parser.parse_args()
     main(args)

--- a/product-base/makefile
+++ b/product-base/makefile
@@ -2,6 +2,7 @@ include ../versions.mk
 IMAGENAME  = product-base
 MATURITY ?= DEV
 BUILD_NUMBER  ?= DEV
+FROM_IMAGE ?= zenoss-centos-base:1.2.4
 
 TAG = zenoss/$(IMAGENAME):$(VERSION)_$(BUILD_NUMBER)_$(MATURITY)
 
@@ -18,11 +19,11 @@ clean:
 	rm -f $(SHORT_VERSION).x/pull-docker-images.sh
 	-docker rmi -f $(TAG)
 
-component_versions: component_info 
+component_versions: component_info
 	@cp ../artifact_download.py ../component_versions.json component_info/.
 
 component_info:
-	@mkdir component_info 
+	@mkdir component_info
 
 $(SHORT_VERSION).x/pull-docker-images.sh:
 	@mkdir -p $(SHORT_VERSION).x
@@ -30,4 +31,4 @@ $(SHORT_VERSION).x/pull-docker-images.sh:
 	@chmod +x $@
 
 Dockerfile:
-	@sed -e 's/%SHORT_VERSION%/$(SHORT_VERSION)/g;'  Dockerfile.in > $@
+	@sed -e 's/%SHORT_VERSION%/$(SHORT_VERSION)/g; s/%FROM_IMAGE%/$(FROM_IMAGE)/g;' Dockerfile.in > $@

--- a/product-base/makefile
+++ b/product-base/makefile
@@ -4,7 +4,7 @@ MATURITY ?= DEV
 BUILD_NUMBER  ?= DEV
 FROM_IMAGE ?= zenoss-centos-base:1.2.4
 
-TAG = zenoss/$(IMAGENAME):$(VERSION)_$(BUILD_NUMBER)_$(MATURITY)
+TAG ?= zenoss/$(IMAGENAME):$(VERSION)_$(BUILD_NUMBER)_$(MATURITY)
 
 .PHONY: build push clean
 

--- a/product-base/makefile
+++ b/product-base/makefile
@@ -2,7 +2,7 @@ include ../versions.mk
 IMAGENAME  = product-base
 MATURITY ?= DEV
 BUILD_NUMBER  ?= DEV
-FROM_IMAGE ?= zenoss-centos-base:1.2.4
+FROM_IMAGE ?= zenoss-centos-base:1.2.5
 
 TAG ?= zenoss/$(IMAGENAME):$(VERSION)_$(BUILD_NUMBER)_$(MATURITY)
 
@@ -43,4 +43,4 @@ $(SHORT_VERSION).x/pull-docker-images.sh:
 	@chmod +x $@
 
 Dockerfile:
-	@sed -e 's/%SHORT_VERSION%/$(SHORT_VERSION)/g; s/%FROM_IMAGE%/$(FROM_IMAGE)/g;' Dockerfile.in > $@
+	@sed -e 's/%SHORT_VERSION%/$(SHORT_VERSION)/g; s/%FROM_IMAGE%/$(FROM_IMAGE)/g; s/%INSTALL_OPTIONS%/$(INSTALL_OPTIONS)/g;' Dockerfile.in > $@

--- a/product-base/makefile
+++ b/product-base/makefile
@@ -6,10 +6,22 @@ FROM_IMAGE ?= zenoss-centos-base:1.2.4
 
 TAG ?= zenoss/$(IMAGENAME):$(VERSION)_$(BUILD_NUMBER)_$(MATURITY)
 
-.PHONY: build push clean
+.PHONY: change-from-image build-deps build build-devimg push clean
 
-build:  component_versions $(SHORT_VERSION).x/pull-docker-images.sh Dockerfile
+build-deps: component_versions $(SHORT_VERSION).x/pull-docker-images.sh Dockerfile
+
+build: build-deps
 	docker build --no-cache=true -t $(TAG) .
+
+# To build the dev image, change the FROM_IMAGE value to use the .devtools base
+# image and then build like any other product-base image.
+build-devimg: change-from-image build
+
+change-from-image:
+	$(eval FROM_IMAGE = $(FROM_IMAGE).devtools)
+	@echo "Building an image for development with FROM_IMAGE=$(FROM_IMAGE)"
+	# Force creation of a new Dockerfile to minimize rebuild confusion
+	rm -f Dockerfile
 
 push:
 	docker push $(TAG)


### PR DESCRIPTION
See comments in [devimg/makefile](./devimg/makefile) for more details on how devimg is built.

A typical invocation by zendev would look something like:
```
cdz product-asembly
cd devimg
ZENDEV_ROOT=$HOME/src/metis SRCROOT=$HOME/src/metis/src TARGET_PRODUCT=core make clean build
```

The result will be two docker images:
```
zendev/devimg:metis
zendev/devimg-base:metis
```