### PR TITLE
More refinement found during devimg work

### DIFF
--- a/devimg/build.sh
+++ b/devimg/build.sh
@@ -43,6 +43,16 @@ then
 	exit 1
 fi
 
+# Always try to remove the docker container, even on a failed exit.
+cleanup() {
+	if [ ! -z "${CONTAINER_ID}" ]
+	then
+		docker ps -qa --no-trunc | grep ${CONTAINER_ID} | xargs --no-run-if-empty docker rm -f
+	fi
+	rm -f ${CONTAINER_ID_FILE}
+}
+trap cleanup EXIT
+
 echo "Initializing Zenoss and installing Zenpacks ..."
 echo "   ZENHOME=${ZENDEV_ROOT}/zenhome"
 echo "   VAR_ZENOSS=${ZENDEV_ROOT}/var_zenoss"
@@ -70,6 +80,3 @@ docker run \
 echo "Committing all of the changes to ${TAG}"
 CONTAINER_ID=`cat ${CONTAINER_ID_FILE}`
 docker commit ${CONTAINER_ID} ${TAG}
-
-docker rm -f ${CONTAINER_ID}
-rm -f ${CONTAINER_ID_FILE}

--- a/product-base/install_scripts/zp_install.py
+++ b/product-base/install_scripts/zp_install.py
@@ -13,9 +13,7 @@ def main(args):
         dirList = os.listdir(args.zpDir)
         zpFileName = fnmatch.filter(dirList, zpGlob)
         if not zpFileName or len(zpFileName) != 1:
-            # TODO: this needs to raise if zenpack was not found
-            # raise Exception("zenpack file not found for zenpack: %s" % zpName)
-            print "zenpack file not found for zenpack: %s" % zpName
+            raise Exception("zenpack file not found for zenpack: %s" % zpName)
         else:
             zpFile = os.path.join(args.zpDir, zpFileName[0])
             print "Installing zenpack: %s %s" % (zpName, zpFile)


### PR DESCRIPTION
1. Always remove the devimg build container
2. Fail the build if a requested zenpack can not be installed 