### PR TITLE
Switch default repo URL to SSH format for easier interop with jig

### DIFF
--- a/artifact_download.py
+++ b/artifact_download.py
@@ -446,7 +446,7 @@ class ArtifactInfo(object):
         """
         if 'git_repo' in self.info:
             return self.info['git_repo']
-        return 'https://github.com/%s/%s.git' % (self.gitOwner, self.info['name'])
+        return 'git@github.com:%s/%s.git' % (self.gitOwner, self.info['name'])
 
     @property
     def gitRef(self):


### PR DESCRIPTION
Also makes it easier for developers how have SSH creds setup of jenkins.