### PR TITLE
Log URL of other types of download exceptions

### DIFF
--- a/artifact_download.py
+++ b/artifact_download.py
@@ -273,9 +273,12 @@ def jenkinsDownload(versionInfo, outdir, downloadReport):
 
     try:
         response = json.loads(urllib2.urlopen(queryURL).read())
+    except urllib2.URLError as e:
+        raise Exception("Error downloading %s: %s" % (queryURL, e))
     except urllib2.HTTPError as e:
         raise Exception("Error downloading %s: %s" % (queryURL, e))
-
+    except httplib.HTTPException, e:
+        raise Exception("Error downloading %s: %s" % (queryURL, e))
 
 
     #


### PR DESCRIPTION
A recent pipeline job failed to download an artifact that should have been there.   There had been some recent networking problems so perhaps it was a temporary DNS or routing issue, but it was impossible to tell from the build log. This change reports the URL for a wider range of exceptions so if a similar problem occurs in the future, we will at least get the full URL for the jenkins download that failed.

Here is the error message from the build log that prompted this change:
```
[0m[91m+ artifactDownload zenoss.metric.consumer
+ local artifact=zenoss.metric.consumer
+ su - zenoss -c '/opt/zenoss/install_scripts/artifact_download.py --out_dir /tmp /opt/zenoss/install_scripts/component_versions.json zenoss.metric.consumer --reportFile /opt/zenoss/log/zenoss_component_artifact.log'
[0m[91mTraceback (most recent call last):
  File "/opt/zenoss/install_scripts/artifact_download.py", line 616, in <module>
    main(options)
  File "/opt/zenoss/install_scripts/artifact_download.py", line 403, in main
    downloadArtifacts(options.versions, artifacts, options.out_dir, downloadReport)
  File "/opt/zenoss/install_scripts/artifact_download.py", line 364, in downloadArtifacts
    downloaders[versionInfo['type']](versionInfo, downloadDir, downloadReport)
  File "/opt/zenoss/install_scripts/artifact_download.py", line 275, in jenkinsDownload
    response = json.loads(urllib2.urlopen(queryURL).read())
  File "/usr/lib64/python2.7/urllib2.py", line 154, in urlopen
[0m[91m    return opener.open(url, data, timeout)
  File "/usr/lib64/python2.7/urllib2.py", line 431, in open
    response = self._open(req, data)
[0m[91m  File "/usr/lib64/python2.7/urllib2.py", line 449, in _open
    '_open', req)
  File "/usr/lib64/python2.7/urllib2.py", line 409, in _call_chain
    result = func(*args)
  File "/usr/lib64/python2.7/urllib2.py", line 1244, in http_open
[0m[91m    return self.do_open(httplib.HTTPConnection, req)
  File "/usr/lib64/python2.7/urllib2.py", line 1214, in do_open
    raise URLError(err)
urllib2.URLError: <urlopen error [Errno -2] Name or service not known>
[0mThe command '/bin/sh -c /opt/zenoss/install_scripts/zenoss_component_install.sh' returned a non-zero code: 1
make: *** [build] Error 1
```