### PR TITLE
blacklist catalog service from devimg

### DIFF
--- a/devimg/create_devimg.sh
+++ b/devimg/create_devimg.sh
@@ -27,11 +27,17 @@ rm -rf ${ZENHOME}/webapps/zeneventserver
 su - zenoss -c "ln -s ${SRCROOT}/zenoss-zep ${ZENHOME}/webapps/zeneventserver"
 
 #TODO: do we want to do this for prodbin bin files as well?
-for srcfile in ${SRCROOT}/zenoss-zep/dist/src/assembly/bin/*; do
-    filename=$(basename "$srcfile")
-    rm -f ${ZENHOME}/bin/${filename}
-    su - zenoss -c "ln -s ${srcfile} ${ZENHOME}/bin/${filename}"
-done
+if [ -d ${SRCROOT}/zenoss-zep/dist/src/assembly/bin ]
+then
+    for srcfile in ${SRCROOT}/zenoss-zep/dist/src/assembly/bin/*; do
+        filename=$(basename "$srcfile")
+        rm -f ${ZENHOME}/bin/${filename}
+        su - zenoss -c "ln -s ${srcfile} ${ZENHOME}/bin/${filename}"
+    done
+else
+    echo "${SRCROOT}/zenoss-zep/dist/src/assembly/bin does not exist"
+    exit 1
+fi
 
 
 

--- a/devimg/makefile
+++ b/devimg/makefile
@@ -28,9 +28,10 @@
 #
 # ZENDEV_ROOT     the parent directory created by zendev which contains the
 #                 zenhome and var_zenoss subdirectories. In other words, the
-#                 developer's ZENHOME=$ZENDEV_ROOT/zenhome.
-# SRCROOT         the root directory of the zendev's environment source code.
-#                 Typically, something like $HOME/src/<envName>/src
+#                 developer's ZENHOME=$ZENDEV_ROOT/zenhome; aka
+#                 $HOME/src/<envName>/zenhome
+# SRCROOT         the root directory of the Zenoss source code.
+#                 Typically, something like $HOME/src/<envName>/src/github.com/zenoss
 #
 # The following input variables are OPTIONAL. They may be set in various special
 # circumstances, but in most case only TARGET_PRODUCT is specified
@@ -42,6 +43,9 @@
 #                 The file name must be "zenpacks.json".
 #                 For example, ZENPACK_FILE=../core/zenpacks.json is equivalent
 #                 to TARGET_PRODUCT=core
+# ZENPACK_BLACKLIST The path to a "zp_blacklist.json" file which contains a list
+#                 of ZenPacks to be excluded from the image.
+#                 If not specifeid, defaults to ../devimg/zp_blacklist.json
 #
 include ../versions.mk
 IMAGENAME  = devimg
@@ -49,6 +53,7 @@ DEV_ENV ?= metis
 TAG = zendev/$(IMAGENAME):$(DEV_ENV)
 BASE_TAG = zendev/$(IMAGENAME)-base:$(DEV_ENV)
 DIR = ${CURDIR}
+ZENPACK_BLACKLIST ?= ${CURDIR}/zp_blacklist.json
 
 CONTAINER_ZENHOME=/opt/zenoss
 
@@ -65,7 +70,7 @@ endif
 # Note that this list includes the directories used as mount points. We create
 # need to create those directories here so they are owned by the current user
 # (otherwise, they will be owned by root when docker creates them).
-make-dirs: verifyInputs $(ZENDEV_ROOT)/zenhome  $(ZENDEV_ROOT)/var_zenoss 
+make-dirs: verifyInputs $(ZENDEV_ROOT)/zenhome  $(ZENDEV_ROOT)/var_zenoss
 	@mkdir -p $$HOME/.m2
 
 $(ZENDEV_ROOT)/%:
@@ -84,6 +89,8 @@ endif
 endif
 	@echo "ZENPACK_FILE='$(ZENPACK_FILE)'"
 	@if [ ! -f $(ZENPACK_FILE) ]; then echo "ZENPACK_FILE=$(ZENPACK_FILE) does not exist"; exit 1; fi
+	@echo "ZENPACK_BLACKLIST='$(ZENPACK_BLACKLIST)'"
+	@if [ ! -f $(ZENPACK_BLACKLIST) ]; then echo "ZENPACK_BLACKLIST=$(ZENPACK_BLACKLIST) does not exist"; exit 1; fi
 
 #
 # four major steps to creating the devimg:
@@ -128,3 +135,5 @@ add-zenpack-file:
 		cp $(ZENPACK_FILE) $(ZENDEV_ROOT)/zenhome/install_scripts; \
 	fi
 	@echo "No downloaded zenpacks; all zenpacks link-installed from source" > $(ZENDEV_ROOT)/zenhome/log/zenpacks_artifact.log
+	@echo "Using the zenpack blacklist defined by $(ZENPACK_BLACKLIST)"
+	cp $(ZENPACK_BLACKLIST) $(ZENDEV_ROOT)/zenhome/install_scripts/zp_blacklist.json

--- a/devimg/zp_blacklist.json
+++ b/devimg/zp_blacklist.json
@@ -1,0 +1,3 @@
+[
+"ZenPacks.zenoss.CatalogService"
+]

--- a/product-base/install_scripts/zenoss_init.sh
+++ b/product-base/install_scripts/zenoss_init.sh
@@ -86,7 +86,7 @@ if [ -f "${ZENHOME}/install_scripts/zenpacks.json" ]; then
     else
        LINK_INSTALL="--link"
     fi
-    su - zenoss  -c "${ZENHOME}/install_scripts/zp_install.py ${ZENHOME}/install_scripts/zenpacks.json ${ZENHOME}/packs ${LINK_INSTALL}"
+    su - zenoss  -c "${ZENHOME}/install_scripts/zp_install.py ${ZENHOME}/install_scripts/zenpacks.json ${ZENHOME}/packs ${ZENHOME}/install_scripts/zp_blacklist.json ${LINK_INSTALL}"
 
     echo "Stopping zeneventserver..."
     su - zenoss  -c "${ZENHOME}/bin/zeneventserver stop"

--- a/product-base/install_scripts/zp_install.py
+++ b/product-base/install_scripts/zp_install.py
@@ -8,7 +8,14 @@ import sys
 
 def main(args):
     manifest = json.load(args.zp_manifest)
+    blacklist = []
+    if args.zp_blacklist:
+        blacklist = json.load(args.zp_blacklist)
     for zpName in manifest['install_order']:
+        if zpName in blacklist:
+            print "Skipping blacklisted ZenPack %s" % zpName
+            continue
+
         zpGlob = '%s-*' % zpName
         if args.link:
             #exact match for link install
@@ -39,5 +46,7 @@ if __name__ == '__main__':
                         help='directory where zenpacks are, defaults to pwd')
     parser.add_argument('--link', action="store_true",
                         help='link-install the zenpacks')
+    parser.add_argument('zp_blacklist', type=file, nargs="?",
+                        help='json file with list of zenpacks to be blacklisted from the install')
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
Adds the notion of a generic blacklist for zenpacks when building devimg.  The default list resides in `product-assembly/devimg/zp_blacklist.json` and currently is limited to just the CatalogService zenpack.

The makefile for devimg allows the caller to specify an override via the environment variable `ZENPACK_BLACKLIST` but I didn't extend that capability to zendev because it seems like a rare use case.   However, a zendev user can specify a custom list with a command like `ZENPACK_BLACKLIST=/path/to/my/custom/blacklist.json zendev devimg`

To test, I did the following:
```
zendev devimg --clean -p resmgr
zendev serviced -dx
<< start Zenoss.core services and verify all healthchecks >>
```