### PR TITLE
Make zp_blacklist.json optional for regular product builds

### DIFF
--- a/product-base/install_scripts/zenoss_init.sh
+++ b/product-base/install_scripts/zenoss_init.sh
@@ -83,10 +83,12 @@ if [ -f "${ZENHOME}/install_scripts/zenpacks.json" ]; then
     if [ -z "${BUILD_DEVIMG}" ]
     then
        LINK_INSTALL=""
+       ZENPACK_BLACKLIST=""
     else
        LINK_INSTALL="--link"
+       ZENPACK_BLACKLIST="${ZENHOME}/install_scripts/zp_blacklist.json"
     fi
-    su - zenoss  -c "${ZENHOME}/install_scripts/zp_install.py ${ZENHOME}/install_scripts/zenpacks.json ${ZENHOME}/packs ${ZENHOME}/install_scripts/zp_blacklist.json ${LINK_INSTALL}"
+    su - zenoss  -c "${ZENHOME}/install_scripts/zp_install.py ${ZENHOME}/install_scripts/zenpacks.json ${ZENHOME}/packs ${ZENPACK_BLACKLIST} ${LINK_INSTALL}"
 
     echo "Stopping zeneventserver..."
     su - zenoss  -c "${ZENHOME}/bin/zeneventserver stop"

--- a/product-base/install_scripts/zp_install.py
+++ b/product-base/install_scripts/zp_install.py
@@ -10,7 +10,10 @@ def main(args):
     manifest = json.load(args.zp_manifest)
     blacklist = []
     if args.zp_blacklist:
-        blacklist = json.load(args.zp_blacklist)
+        print "ZenPack blacklist='%s'" % args.zp_blacklist
+        with open(args.zp_blacklist) as blacklistFile:
+            blacklist = json.load(blacklistFile)
+
     for zpName in manifest['install_order']:
         if zpName in blacklist:
             print "Skipping blacklisted ZenPack %s" % zpName
@@ -46,7 +49,7 @@ if __name__ == '__main__':
                         help='directory where zenpacks are, defaults to pwd')
     parser.add_argument('--link', action="store_true",
                         help='link-install the zenpacks')
-    parser.add_argument('zp_blacklist', type=file, nargs="?",
+    parser.add_argument('zp_blacklist', type=str, nargs="?",
                         help='json file with list of zenpacks to be blacklisted from the install')
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
Without this change `make core` and `make resmgr` fail because they do not find `zp_blacklist.json` in the product-base image.