### PR TITLE
Use pre for the PredictiveThreshold zenpack

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -148,7 +148,8 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.PredictiveThreshold",
-        "type": "zenpack"
+        "type": "zenpack",
+        "pre": true
     },{
         "name": "ZenPacks.zenoss.PortalIntegration",
         "type": "zenpack"


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-25878

Per Glenn's recommendation, we can use develop for PredictiveThreshold.
It has commits with an important fix and a unit test fix.

Pending the next release of PredictiveThreshold, it might be a good idea to set it back to using latest release version.