### PR TITLE
Update NetScreenMonitor version to fix unit-tests

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -139,7 +139,8 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.NetScreenMonitor",
-        "type": "zenpack"
+        "type": "zenpack",
+        "pre": true
     },{
         "name": "ZenPacks.zenoss.NortelMonitor",
         "type": "zenpack"


### PR DESCRIPTION
ZEN-25880 - Upgrade to latest dev version of NetScreenMonitor to fix unit-test failure