### PR TITLE
Use service-migration 1.1.3

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -33,7 +33,7 @@
         "git_owner": "control-center",
         "name": "service-migration",
         "type": "download",
-        "version": "1.1.2"
+        "version": "1.1.3"
     },
     {
         "URL": "http://zenpip.zendev.org/packages/zenoss.extjs-{version}.tar.gz",


### PR DESCRIPTION
This service-migration 1.1.3 is identical to 1.1.2; it was created in error.  However, we are using the latest in order to avoid future confusion.