### PR TITLE
Update NetScreenMonitor: unstable to stable

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -139,8 +139,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.NetScreenMonitor",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.NortelMonitor",
         "type": "zenpack"


### PR DESCRIPTION
NetScreenMonitor was pointed to latest unstable build by 7593993 to pull
in a unit test fix for ZEN-25880. That fix has since been released in
2.2.2 via zenoss/ZenPacks.zenoss.NetScreenMonitor@1be8f20.