### PR TITLE
Update vSphere: 3.5.* to stable

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -182,9 +182,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.vSphere",
-        "type": "zenpack",
-        "requirement": "ZenPacks.zenoss.vSphere==3.5.*",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.WBEM",
         "type": "zenpack"


### PR DESCRIPTION
vSphere was pointed to latest 3.5.* unstable build by d51720c and
00b569e to fix a unit test failure affecting the Metis build. The fix
for this unit test failure has now been released in vSphere 3.5.2 via
zenoss/ZenPacks.zenoss.vSphere@3f48715.