### PR TITLE
Add make target to dump clean, updated zodb

### DIFF
--- a/devimg/docker_run_dumpzodb.sh
+++ b/devimg/docker_run_dumpzodb.sh
@@ -5,16 +5,19 @@
 # This script assumes that zendev/devimg already exists; see build.sh.
 # This script runs dump_zodb.sh in zendev/devimg with several key
 # directories in the image bind-mounted to source directories in the developer's
-# local sandbox.  The dump_zodb.sh script creates a clean base zodb from the XML files
+# local sandbox.  The dump_zodb.sh script creates a clean base zodb from the XML files or gz file
 # on the developer's local sandbox (zenoss-prodbin/Products/ZenModel/data).  It then migrates
 # the database to the latest version based on the migrate scripts found in ZenModel/migrate.
 # Finally, it dumps an updated set of xml files and an updated .gz file back out to 
-# zenoss-prodbin/ProductsZenModel/data
+# zenoss-prodbin/Products/ZenModel/data
 #
 # Required Arguments (specified as environment variables):
 # TAG         - the full docker tag of the devimage to use (e.g. zendev/devimg:<envName>)
 # ZENDEV_ROOT - see the description in makefile
 # SRCROOT     - see the description in makefile
+#
+# Optional Argument
+# ZENWIPE_ARGS - set to '--xml' to load DB from XML files, or leave empty to use .gz file
 
 if [ -z "${TAG}" ]
 then

--- a/devimg/docker_run_dumpzodb.sh
+++ b/devimg/docker_run_dumpzodb.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# dump_db.sh - build zendev/devimg.
+#
+# This script assumes that zendev/devimg already exists; see build.sh.
+# This script runs dump_zodb.sh in zendev/devimg with several key
+# directories in the image bind-mounted to source directories in the developer's
+# local sandbox.  The dump_zodb.sh script creates a clean base zodb from the XML files
+# on the developer's local sandbox (zenoss-prodbin/Products/ZenModel/data).  It then migrates
+# the database to the latest version based on the migrate scripts found in ZenModel/migrate.
+# Finally, it dumps an updated set of xml files and an updated .gz file back out to 
+# zenoss-prodbin/ProductsZenModel/data
+#
+# Required Arguments (specified as environment variables):
+# TAG         - the full docker tag of the devimage to use (e.g. zendev/devimg:<envName>)
+# ZENDEV_ROOT - see the description in makefile
+# SRCROOT     - see the description in makefile
+
+if [ -z "${TAG}" ]
+then
+	echo "ERROR: Missing required argument - TAG"
+	exit 1
+elif [ -z "${ZENDEV_ROOT}" ]
+then
+	echo "ERROR: Missing required argument - ZENDEV_ROOT"
+	exit 1
+elif [ -z "${SRCROOT}" ]
+then
+	echo "ERROR: Missing required argument - SRCROOT"
+fi
+
+# Always try to remove the docker container, even on a failed exit.
+cleanup() {
+	if [ ! -z "${CONTAINER_ID}" ]
+	then
+		docker ps -qa --no-trunc | grep ${CONTAINER_ID} | xargs --no-run-if-empty docker rm -f
+	fi
+	rm -f ${CONTAINER_ID_FILE}
+}
+trap cleanup EXIT
+
+echo "Preparing to clean, migrate and dump zodb ..."
+echo "   ZENHOME=${ZENDEV_ROOT}/zenhome"
+echo "   VAR_ZENOSS=${ZENDEV_ROOT}/var_zenoss"
+echo "   SRCROOT=${SRCROOT}"
+echo "   ZENWIPE_ARGS=${ZENWIPE_ARGS}"
+
+CONTAINER_ID_FILE=containerID.txt
+rm -f ${CONTAINER_ID_FILE}
+
+set -e
+set -x
+
+# Run dump_zodb.sh, record the container id and CONTAINER_ID_FILE so we can
+# be sure the container gets cleaned up on exit
+#
+PWD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+echo "docker run \
+	--rm \
+	--cidfile ${CONTAINER_ID_FILE} \
+	-v ${ZENDEV_ROOT}/zenhome:/opt/zenoss \
+	-v ${ZENDEV_ROOT}/var_zenoss:/var/zenoss \
+	-v ${SRCROOT}:/mnt/src \
+	-v ${PWD}:/mnt/devimg \
+        -v ${HOME}/.m2:/home/zenoss/.m2 \
+        -t ${TAG} \
+	/mnt/devimg/dump_zodb.sh ${ZENWIPE_ARGS}
+"
+docker run \
+	--rm \
+	--cidfile ${CONTAINER_ID_FILE} \
+	-v ${ZENDEV_ROOT}/zenhome:/opt/zenoss \
+	-v ${ZENDEV_ROOT}/var_zenoss:/var/zenoss \
+	-v ${SRCROOT}:/mnt/src \
+	-v ${PWD}:/mnt/devimg \
+        -v ${HOME}/.m2:/home/zenoss/.m2 \
+        -t ${TAG} \
+	/mnt/devimg/dump_zodb.sh ${ZENWIPE_ARGS}
+

--- a/devimg/dump_zodb.sh
+++ b/devimg/dump_zodb.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # load the installation functions
+#   so we can use start_requirements
 . ${ZENHOME}/install_scripts/install_lib.sh
 
 
@@ -37,7 +38,6 @@ su - zenoss -c "cd /opt/zenoss/Products/ZenModel/data && ./exportXml.sh"
 echo "Stopping mysql..."
 mysqladmin shutdown
 
-#TODO stop and clean content of rabbit queues
 echo "Stopping redis..."
 pkill redis
 

--- a/devimg/dump_zodb.sh
+++ b/devimg/dump_zodb.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# load the installation functions
+. ${ZENHOME}/install_scripts/install_lib.sh
+
+
+if [ -z "${SRCROOT}" ]
+then
+    SRCROOT=/mnt/src
+fi
+
+if [ ! -d "${SRCROOT}" ]
+then
+    echo "ERROR: SRCROOT=${SRCROOT} does not exist"
+    exit 1
+fi
+
+set -e
+set -x
+
+echo "Starting required applications ..."
+
+start_requirements
+
+/usr/lib/rabbitmq/bin/rabbitmq-plugins enable rabbitmq_management
+/sbin/rabbitmqctl stop
+sleep 5
+rm -r /var/lib/rabbitmq/mnesia/rabbit@rbt0.pid
+/usr/sbin/rabbitmq-server 2>&1 > ${ZENHOME}/log/rabbitmq.log &
+rabbitmqctl wait /var/lib/rabbitmq/mnesia/rabbit@rbt0.pid
+
+echo "Running zenwipe.sh $@"
+su - zenoss -c "/opt/zenoss/bin/zenwipe.sh $@"
+echo "Running exportXml"
+su - zenoss -c "cd /opt/zenoss/Products/ZenModel/data && ./exportXml.sh"
+
+echo "Stopping mysql..."
+mysqladmin shutdown
+
+#TODO stop and clean content of rabbit queues
+echo "Stopping redis..."
+pkill redis
+
+echo "Stopping rabbit..."
+/sbin/rabbitmqctl stop
+
+sleep 10
+echo "Cleaning up mysql data..."
+rm /var/lib/mysql/ib_logfile0
+rm /var/lib/mysql/ib_logfile1
+
+echo "Cleaning up after install..."
+find ${ZENHOME} -name \*.py[co] -delete
+rm -f ${ZENHOME}/log/\*.log
+/sbin/scrub.sh
+
+echo "Finished dumping zodb"
+
+
+

--- a/devimg/makefile
+++ b/devimg/makefile
@@ -109,6 +109,12 @@ build: make-dirs select-zenpacks build-devbase initialize-zenhome add-zenpack-fi
 	ZENDEV_ROOT=$(ZENDEV_ROOT) \
 	./build.sh
 
+dumpdb: 
+	TAG=$(TAG) \
+	ZENDEV_ROOT=$(ZENDEV_ROOT) \
+	ZENWIPE_ARGS=$(ZENWIPE_ARGS) \
+	./docker_run_dumpzodb.sh
+
 clean:
 	-cd ../product-base;TAG=$(BASE_TAG) make clean
 	@echo "Removing $(TAG) (if any)..."


### PR DESCRIPTION
"make dumpdb" will start a new container based on devimg, start mariadb, redis, and rabbit, then wipe, reload, migrate, and dump the updated zodb XML and .gz files.