### PR TITLE
pin MSWin zenpack to hotfix 2.6.8 for ZEN-26086

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -127,7 +127,8 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.Windows",
-        "type": "zenpack"
+        "type": "zenpack",
+        "requirement": "ZenPacks.zenoss.Microsoft.Windows==2.6.8"
     },{
         "name": "ZenPacks.zenoss.MySqlMonitor",
         "type": "zenpack"


### PR DESCRIPTION
pin ZenPacks.zenoss.Microsoft.Windows version to hotfix 2.6.8