### PR TITLE
Pin most ZenPack versions for 5.2.0 release

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -1,21 +1,27 @@
 [
     {
         "name": "ZenPacks.zenoss.AdvancedSearch",
+        "requirement": "ZenPacks.zenoss.AdvancedSearch===1.2.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.AixMonitor",
+        "requirement": "ZenPacks.zenoss.AixMonitor===2.2.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ApacheMonitor",
+        "requirement": "ZenPacks.zenoss.ApacheMonitor===2.1.4",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.AuditLog",
+        "requirement": "ZenPacks.zenoss.AuditLog===1.4.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.BigIpMonitor",
+        "requirement": "ZenPacks.zenoss.BigIpMonitor===2.7.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.BrocadeMonitor",
+        "requirement": "ZenPacks.zenoss.BrocadeMonitor===2.1.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CalculatedPerformance",
@@ -23,196 +29,251 @@
         "pre": true
     },{
         "name": "ZenPacks.zenoss.CatalogService",
-        "requirement": "ZenPacks.zenoss.CatalogService==3.1.1",
+        "requirement": "ZenPacks.zenoss.CatalogService===3.1.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CheckPointMonitor",
+        "requirement": "ZenPacks.zenoss.CheckPointMonitor===2.0.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoMonitor",
+        "requirement": "ZenPacks.zenoss.CiscoMonitor===5.7.3",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCS",
+        "requirement": "ZenPacks.zenoss.CiscoUCS===2.5.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCSCentral",
+        "requirement": "ZenPacks.zenoss.CiscoUCSCentral===1.2.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ComponentGroups",
-        "type": "zenpack",
-        "requirement": "ZenPacks.zenoss.ComponentGroups==1.2.0"
+        "requirement": "ZenPacks.zenoss.ComponentGroups===1.2.0",
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ControlCenter",
-        "type": "zenpack",
-        "requirement": "ZenPacks.zenoss.ControlCenter==1.3.0"
+        "requirement": "ZenPacks.zenoss.ControlCenter===1.3.0",
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Dashboard",
-        "type": "zenpack",
-        "requirement": "ZenPacks.zenoss.Dashboard==1.2.4"
+        "requirement": "ZenPacks.zenoss.Dashboard===1.2.4",
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DellMonitor",
+        "requirement": "ZenPacks.zenoss.DellMonitor===2.2.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DeviceSearch",
+        "requirement": "ZenPacks.zenoss.DeviceSearch===1.2.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Diagram",
+        "requirement": "ZenPacks.zenoss.Diagram===1.3.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DigMonitor",
+        "requirement": "ZenPacks.zenoss.DigMonitor===1.1.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DiscoveryMapping",
+        "requirement": "ZenPacks.zenoss.DiscoveryMapping===1.2.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DistributedCollector",
+        "requirement": "ZenPacks.zenoss.DistributedCollector===3.1.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DnsMonitor",
+        "requirement": "ZenPacks.zenoss.DnsMonitor===2.1.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DynamicView",
-        "requirement": "ZenPacks.zenoss.DynamicView==1.5.0",
+        "requirement": "ZenPacks.zenoss.DynamicView===1.5.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.EMC.base",
+        "requirement": "ZenPacks.zenoss.EMC.base===1.1.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.EnterpriseCollector",
+        "requirement": "ZenPacks.zenoss.EnterpriseCollector===1.7.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.EnterpriseReports",
+        "requirement": "ZenPacks.zenoss.EnterpriseReports===2.4.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.EnterpriseSecurity",
+        "requirement": "ZenPacks.zenoss.EnterpriseSecurity===1.2.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.EnterpriseSkin",
+        "requirement": "ZenPacks.zenoss.EnterpriseSkin===3.3.4",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.FtpMonitor",
+        "requirement": "ZenPacks.zenoss.FtpMonitor===1.1.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.HPMonitor",
+        "requirement": "ZenPacks.zenoss.HPMonitor===2.1.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.HpuxMonitor",
+        "requirement": "ZenPacks.zenoss.HpuxMonitor===2.0.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.HttpMonitor",
+        "requirement": "ZenPacks.zenoss.HttpMonitor===2.1.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.InstalledTemplatesReport",
+        "requirement": "ZenPacks.zenoss.InstalledTemplatesReport===1.1.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.JBossMonitor",
+        "requirement": "ZenPacks.zenoss.JBossMonitor===2.4.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.JuniperMonitor",
+        "requirement": "ZenPacks.zenoss.JuniperMonitor===2.1.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.LDAPAuthenticator",
+        "requirement": "ZenPacks.zenoss.LDAPAuthenticator===3.3.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.LDAPMonitor",
+        "requirement": "ZenPacks.zenoss.LDAPMonitor===1.4.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Licensing",
+        "requirement": "ZenPacks.zenoss.Licensing===0.2.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.LinuxMonitor",
+        "requirement": "ZenPacks.zenoss.LinuxMonitor===2.1.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.HyperV",
+        "requirement": "ZenPacks.zenoss.Microsoft.HyperV===1.3.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.Windows",
-        "type": "zenpack",
-        "requirement": "ZenPacks.zenoss.Microsoft.Windows==2.6.8"
+        "requirement": "ZenPacks.zenoss.Microsoft.Windows===2.6.8",
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.MySqlMonitor",
+        "requirement": "ZenPacks.zenoss.MySqlMonitor===3.0.7",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.NetAppMonitor",
+        "requirement": "ZenPacks.zenoss.NetAppMonitor===3.3.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.NetScaler",
+        "requirement": "ZenPacks.zenoss.NetScaler===1.0.6",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.NetScreenMonitor",
+        "requirement": "ZenPacks.zenoss.NetScreenMonitor===2.2.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.NortelMonitor",
+        "requirement": "ZenPacks.zenoss.NortelMonitor===2.0.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.NtpMonitor",
+        "requirement": "ZenPacks.zenoss.NtpMonitor===2.2.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.PredictiveThreshold",
-        "type": "zenpack",
-        "requirement": "ZenPacks.zenoss.PredictiveThreshold==1.2.0"
+        "requirement": "ZenPacks.zenoss.PredictiveThreshold===1.2.0",
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.PortalIntegration",
+        "requirement": "ZenPacks.zenoss.PortalIntegration===1.1.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.PropertyMonitor",
+        "requirement": "ZenPacks.zenoss.PropertyMonitor===1.1.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.PythonCollector",
+        "requirement": "ZenPacks.zenoss.PythonCollector===1.8.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.SolarisMonitor",
+        "requirement": "ZenPacks.zenoss.SolarisMonitor===2.5.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.StorageBase",
+        "requirement": "ZenPacks.zenoss.StorageBase===1.4.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.SupportBundle",
+        "requirement": "ZenPacks.zenoss.SupportBundle===1.1.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.TomcatMonitor",
+        "requirement": "ZenPacks.zenoss.TomcatMonitor===2.3.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.vCloud",
+        "requirement": "ZenPacks.zenoss.vCloud===1.4.9",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.UCSCapacity",
+        "requirement": "ZenPacks.zenoss.UCSCapacity===1.2.3",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.UCSXSkin",
+        "requirement": "ZenPacks.zenoss.UCSXSkin===2.1.4",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.vSphere",
+        "requirement": "ZenPacks.zenoss.vSphere===3.5.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.WBEM",
+        "requirement": "ZenPacks.zenoss.WBEM===1.0.3",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.WebLogicMonitor",
+        "requirement": "ZenPacks.zenoss.WebLogicMonitor===2.2.3",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.WebsphereMonitor",
+        "requirement": "ZenPacks.zenoss.WebsphereMonitor===1.2.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ZenDeviceACL",
+        "requirement": "ZenPacks.zenoss.ZenDeviceACL===2.2.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ZenJMX",
+        "requirement": "ZenPacks.zenoss.ZenJMX===3.12.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ZenMail",
+        "requirement": "ZenPacks.zenoss.ZenMail===5.1.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ZenMailTx",
+        "requirement": "ZenPacks.zenoss.ZenMailTx===2.6.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ZenOperatorRole",
+        "requirement": "ZenPacks.zenoss.ZenOperatorRole===2.1.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ZenSQLTx",
+        "requirement": "ZenPacks.zenoss.ZenSQLTx===2.6.5",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ZenWebTx",
+        "requirement": "ZenPacks.zenoss.ZenWebTx===3.0.0",
         "type": "zenpack"
     }
 ]


### PR DESCRIPTION
All ZenPack versions are pinned except for CalculatedPerformance. It's
still pointing to the develop branch until testing is finished and an
appropriate stable version is released.

Refs ZEN-25991 and ZEN-26081.