### PR TITLE
Update DigMonitor ZenPack: 1.1.1 to 1.1.0

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -73,7 +73,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DigMonitor",
-        "requirement": "ZenPacks.zenoss.DigMonitor===1.1.1",
+        "requirement": "ZenPacks.zenoss.DigMonitor===1.1.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DiscoveryMapping",


### PR DESCRIPTION
DigMonitor 1.1.1 hasn't been released. I pinned the wrong version in
4435c36 because a glitch in the Jenkins
develop-ZenPacks.zenoss.DigMonitor job built an egg with the stable
1.1.1 release version a while back so it became the newest stable build.

DigMonitor 1.1.0 is the latest stable release, and should be what goes
out with Zenoss 5.2.0.