### PR TITLE
ZEN-25998 Add check_for_old_servicedef to clean target

### DIFF
--- a/product-base/makefile
+++ b/product-base/makefile
@@ -29,6 +29,7 @@ push:
 clean:
 	rm -rf component_info Dockerfile
 	rm -f $(SHORT_VERSION).x/pull-docker-images.sh
+	rm -f $(SHORT_VERSION).x/check_for_old_servicedef.py
 	-docker rmi -f $(TAG)
 
 component_versions: component_info


### PR DESCRIPTION
This change was made to support/5.2.x but not to develop.