### PR TITLE
Update CiscoUCS ZenPack: 2.5.0 to 2.5.2

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -41,7 +41,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCS",
-        "requirement": "ZenPacks.zenoss.CiscoUCS===2.5.0",
+        "requirement": "ZenPacks.zenoss.CiscoUCS===2.5.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCSCentral",


### PR DESCRIPTION
Changes from 2.5.0 to 2.5.2:

- Clarify and reduce chassis and server events (ZEN-25740)
- Fix zCredentialsZProperties override warning on Zenoss 5.2 (ZEN-26164)

https://github.com/zenoss/ZenPacks.zenoss.CiscoUCS/compare/2.5.0...2.5.2