### PR TITLE
Update vSphere ZenPack: 3.5.2 to 3.5.3

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -233,7 +233,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.vSphere",
-        "requirement": "ZenPacks.zenoss.vSphere===3.5.2",
+        "requirement": "ZenPacks.zenoss.vSphere===3.5.3",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.WBEM",


### PR DESCRIPTION
Changes from 3.5.2 to 3.5.3:

- Fix TypeError while adding vSphere hypervisor (ZEN-26197)

https://github.com/zenoss/ZenPacks.zenoss.vSphere/compare/3.5.2...3.5.3