### PR TITLE
Separate maturity levels for zenoss vs serviced

### DIFF
--- a/Jenkins-image.groovy
+++ b/Jenkins-image.groovy
@@ -30,11 +30,13 @@ node ('build-zenoss-product') {
         def SVCDEF_GIT_REF=versionProps['SVCDEF_GIT_REF']
         def ZENOSS_VERSION=versionProps['VERSION']
         def SERVICED_BRANCH=versionProps['SERVICED_BRANCH']
+        def SERVICED_MATURITY=versionProps['SERVICED_MATURITY']
         def SERVICED_VERSION=versionProps['SERVICED_VERSION']
         def SERVICED_BUILD_NBR=versionProps['SERVICED_BUILD_NBR']
         echo "SVCDEF_GIT_REF=${SVCDEF_GIT_REF}"
         echo "ZENOSS_VERSION=${ZENOSS_VERSION}"
         echo "SERVICED_BRANCH=${SERVICED_BRANCH}"
+        echo "SERVICED_MATURITY=${SERVICED_MATURITY}"
         echo "SERVICED_VERSION=${SERVICED_VERSION}"
         echo "SERVICED_BUILD_NBR=${SERVICED_BUILD_NBR}"
 
@@ -87,9 +89,10 @@ node ('build-zenoss-product') {
             [$class: 'StringParameterValue', name: 'JOB_LABEL', value: childJobLabel],
             [$class: 'StringParameterValue', name: 'TARGET_PRODUCT', value: TARGET_PRODUCT],
             [$class: 'StringParameterValue', name: 'PRODUCT_BUILD_NUMBER', value: PRODUCT_BUILD_NUMBER],
-            [$class: 'StringParameterValue', name: 'MATURITY', value: MATURITY],
+            [$class: 'StringParameterValue', name: 'ZENOSS_MATURITY', value: MATURITY],
             [$class: 'StringParameterValue', name: 'ZENOSS_VERSION', value: ZENOSS_VERSION],
             [$class: 'StringParameterValue', name: 'SERVICED_BRANCH', value: SERVICED_BRANCH],
+            [$class: 'StringParameterValue', name: 'SERVICED_MATURITY', value: SERVICED_MATURITY],
             [$class: 'StringParameterValue', name: 'SERVICED_VERSION', value: SERVICED_VERSION],
             [$class: 'StringParameterValue', name: 'SERVICED_BUILD_NBR', value: SERVICED_BUILD_NBR],
         ]

--- a/Jenkins-promote.groovy
+++ b/Jenkins-promote.groovy
@@ -47,12 +47,14 @@ node ('build-zenoss-product') {
         def ZENOSS_VERSION=versionProps['VERSION']
         def ZENOSS_SHORT_VERSION=versionProps['SHORT_VERSION']
         def SERVICED_BRANCH=versionProps['SERVICED_BRANCH']
+        def SERVICED_MATURITY=versionProps['SERVICED_MATURITY']
         def SERVICED_VERSION=versionProps['SERVICED_VERSION']
         def SERVICED_BUILD_NBR=versionProps['SERVICED_BUILD_NBR']
         echo "SVCDEF_GIT_REF=${SVCDEF_GIT_REF}"
         echo "ZENOSS_VERSION=${ZENOSS_VERSION}"
         echo "ZENOSS_SHORT_VERSION=${ZENOSS_SHORT_VERSION}"
         echo "SERVICED_BRANCH=${SERVICED_BRANCH}"
+        echo "SERVICED_MATURITY=${SERVICED_MATURITY}"
         echo "SERVICED_VERSION=${SERVICED_VERSION}"
         echo "SERVICED_BUILD_NBR=${SERVICED_BUILD_NBR}"
 
@@ -110,9 +112,10 @@ node ('build-zenoss-product') {
                 [$class: 'StringParameterValue', name: 'JOB_LABEL', value: childJobLabel],
                 [$class: 'StringParameterValue', name: 'TARGET_PRODUCT', value: TARGET_PRODUCT],
                 [$class: 'StringParameterValue', name: 'PRODUCT_BUILD_NUMBER', value: TO_RELEASEPHASE],
-                [$class: 'StringParameterValue', name: 'MATURITY', value: TO_MATURITY],
+                [$class: 'StringParameterValue', name: 'ZENOSS_MATURITY', value: TO_MATURITY],
                 [$class: 'StringParameterValue', name: 'ZENOSS_VERSION', value: ZENOSS_VERSION],
                 [$class: 'StringParameterValue', name: 'SERVICED_BRANCH', value: SERVICED_BRANCH],
+                [$class: 'StringParameterValue', name: 'SERVICED_MATURITY', value: SERVICED_MATURITY],
                 [$class: 'StringParameterValue', name: 'SERVICED_VERSION', value: SERVICED_VERSION],
                 [$class: 'StringParameterValue', name: 'SERVICED_BUILD_NBR', value: SERVICED_BUILD_NBR],
             ]

--- a/versions.mk
+++ b/versions.mk
@@ -21,7 +21,7 @@ UCSPM_VERSION=2.1.0
 
 #
 # Currently, HDFS and OpenTSDB use the same image as HBASE
-# So these versions should always be the same. 
+# So these versions should always be the same.
 #
 HBASE_VERSION=24.0.2
 HDFS_VERSION=24.0.2
@@ -48,6 +48,11 @@ OPENTSDB_VERSION=24.0.2
 #    SERVICED_VERSION and SERVICED_BLD_NUMBER have to be specified together, and
 #    SERVICED_BRANCH must be blank if both are specified.
 #
+#    If SERVICED_BRANCH is specified, then SERVICED_MATURITY must be 'unstable'.
+#    If SERVICED_VERSION and SERVICED_BUILD_NBR are specified, then the
+#    SERVICED_BRANCH should be 'testing' or 'stable'
+#
 SERVICED_BRANCH=
+SERVICED_MATURITY=stable
 SERVICED_VERSION=1.2.1
 SERVICED_BUILD_NBR=1


### PR DESCRIPTION
Cherry pick #167 for the `support/5.2.x` branch