### PR TITLE
Bump version to 5.2.1

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -43,10 +43,11 @@
         "version": "4.1.3"
     },
     {
-        "URL": "http://zenpip.zendev.org/packages/prodbin-{version}-master-5.2.x.tar.gz",
         "name": "zenoss-prodbin",
-        "type": "download",
-        "version": "5.2.0-2"
+        "type": "jenkins",
+        "jenkins.server": "http://jenkins.zendev.org",
+        "jenkins.job": "zenoss-prodbin-merge-support-52x",
+        "version": "support/5.2.x"
     },
     {
         "URL": "http://zenpip.zendev.org/packages/zenoss.protocols-2.1.4.post1-py2-none-any.whl",

--- a/versions.mk
+++ b/versions.mk
@@ -15,8 +15,8 @@
 # UCSPM_VERSION     the version of the ucspm release; e.g 2.1.0
 #
 SHORT_VERSION=5.2
-SVCDEF_GIT_REF=5.2.0
-VERSION=5.2.0
+SVCDEF_GIT_REF=support/5.2.x
+VERSION=5.2.1
 UCSPM_VERSION=2.1.0
 
 #


### PR DESCRIPTION
This PR should NOT be merged until https://github.com/zenoss/zenoss-prodbin/pull/2010 has been merged and a new 5.2.1 prodbin artifact is available here - http://jenkins.zendev.org/job/zenoss-prodbin-merge-support-52x/