### PR TITLE
ZEN-26254: get develop of Dashboard into support/5.2.x

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -57,8 +57,8 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Dashboard",
-        "requirement": "ZenPacks.zenoss.Dashboard===1.2.4",
-        "type": "zenpack"
+        "type": "zenpack",
+        "pre": true
     },{
         "name": "ZenPacks.zenoss.DellMonitor",
         "requirement": "ZenPacks.zenoss.DellMonitor===2.2.0",


### PR DESCRIPTION
This is for getting this fix https://github.com/zenoss/ZenPacks.zenoss.Dashboard/pull/69 in 5.2.x

[JIRA](https://jira.zenoss.com/browse/ZEN-26254)