### PR TITLE
Untag old preupgrade snapshots before upgrade

### DIFF
--- a/core/upgrade-core.sh.in
+++ b/core/upgrade-core.sh.in
@@ -7,5 +7,7 @@
 ###############################################################################
 set -e
 /root/%SHORT_VERSION%.x/check_for_old_servicedef.py Zenoss.core 5.0.6
+export SERVICE_TENANT_ID="`serviced service list core --format='{{.ID}}'`"
+serviced snapshot untag $SERVICE_TENANT_ID preupgrade-core-%VERSION%
 serviced script run /root/%SHORT_VERSION%.x/upgrade-core.txt --service Zenoss.core
 /opt/serviced/bin/serviced-set-version Zenoss.core %VERSION%

--- a/resmgr/upgrade-resmgr.sh.in
+++ b/resmgr/upgrade-resmgr.sh.in
@@ -7,6 +7,8 @@
 ###############################################################################
 set -e
 /root/%SHORT_VERSION%.x/check_for_old_servicedef.py Zenoss.resmgr 5.0.6
+export SERVICE_TENANT_ID="`serviced service list resmgr --format='{{.ID}}'`"
+serviced snapshot untag $SERVICE_TENANT_ID preupgrade-resmgr-%VERSION%
 if [ $(serviced service status --show-fields Name  Zenoss.resmgr/Infrastructure/Impact | grep Impact) ]; then
     serviced script run /root/%SHORT_VERSION%.x/upgrade-impact.txt --service Zenoss.resmgr
 else


### PR DESCRIPTION
This code was added for UCS-PM for ZEN-24124, but not for
resmgr or core targets.