### PR TITLE
Add ZenPackLib ZenPack: 2.0.0

### DIFF
--- a/core/zenpacks.json
+++ b/core/zenpacks.json
@@ -1,5 +1,6 @@
 {
   "install_order": [
+    "ZenPacks.zenoss.ZenPackLib",
     "ZenPacks.zenoss.ApacheMonitor",
     "ZenPacks.zenoss.PythonCollector",
     "ZenPacks.zenoss.HttpMonitor",

--- a/core/zphistory.json
+++ b/core/zphistory.json
@@ -1,3 +1,3 @@
 {
-
+  "ZenPacks.zenoss.ZenPackLib": "5.2.1"
 }

--- a/resmgr/zenpacks.json
+++ b/resmgr/zenpacks.json
@@ -1,5 +1,6 @@
 {
     "install_order": [
+        "ZenPacks.zenoss.ZenPackLib",
         "ZenPacks.zenoss.ApacheMonitor",
         "ZenPacks.zenoss.PythonCollector",
         "ZenPacks.zenoss.CalculatedPerformance",

--- a/resmgr/zphistory.json
+++ b/resmgr/zphistory.json
@@ -55,6 +55,7 @@
   "ZenPacks.zenoss.ZenMail": "5.0.0",
   "ZenPacks.zenoss.ZenMailTx": "5.0.0",
   "ZenPacks.zenoss.ZenOperatorRole": "5.0.0",
+  "ZenPacks.zenoss.ZenPackLib": "5.2.1",
   "ZenPacks.zenoss.ZenSQLTx": "5.0.0",
   "ZenPacks.zenoss.ZenWebTx": "5.0.0",
   "ZenPacks.zenoss.vCloud": "5.0.0",

--- a/ucspm/zenpacks.json
+++ b/ucspm/zenpacks.json
@@ -1,5 +1,6 @@
 {
     "install_order": [
+        "ZenPacks.zenoss.ZenPackLib",
         "ZenPacks.zenoss.PythonCollector",
         "ZenPacks.zenoss.CalculatedPerformance",
         "ZenPacks.zenoss.ControlCenter",

--- a/ucspm/zphistory.json
+++ b/ucspm/zphistory.json
@@ -35,5 +35,6 @@
   "ZenPacks.zenoss.vSphere": "5.1.0",
   "ZenPacks.zenoss.WBEM": "5.1.0",
   "ZenPacks.zenoss.ZenDeviceACL": "5.1.0",
-  "ZenPacks.zenoss.ZenOperatorRole": "5.1.0"
+  "ZenPacks.zenoss.ZenOperatorRole": "5.1.0",
+  "ZenPacks.zenoss.ZenPackLib": "5.2.1"
 }

--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -203,6 +203,9 @@
         "name": "ZenPacks.zenoss.ZenOperatorRole",
         "type": "zenpack"
     },{
+        "name": "ZenPacks.zenoss.ZenPackLib",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.ZenSQLTx",
         "type": "zenpack"
     },{


### PR DESCRIPTION
ZenPacks are going to start requiring this in the near future. Getting
this into all distributions (core, resmgr, ucspm) now will make
consuming other ZenPack updates easier for users.

Resolves ZPS-586.