### PR TITLE
Update CiscoUCS ZenPack: 2.5.2 to 2.5.4

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -41,7 +41,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCS",
-        "requirement": "ZenPacks.zenoss.CiscoUCS===2.5.2",
+        "requirement": "ZenPacks.zenoss.CiscoUCS===2.5.4",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCSCentral",


### PR DESCRIPTION
Changes from 2.5.2 to 2.5.4:

- Fix collection stall caused by interrupted connectivity. (ZPS-503)

https://github.com/zenoss/ZenPacks.zenoss.CiscoUCS/compare/2.5.2...2.5.4