### PR TITLE
Update Microsoft.Windows ZenPack: 2.6.8 to 2.6.11

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -161,7 +161,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.Windows",
-        "requirement": "ZenPacks.zenoss.Microsoft.Windows===2.6.8",
+        "requirement": "ZenPacks.zenoss.Microsoft.Windows===2.6.11",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.MySqlMonitor",


### PR DESCRIPTION
Changes from 2.6.8 to 2.6.11:

- Fix Monitoring of SQL Instances results in a UUID error. (ZPS-453)
- Added additional event classes and handlers for Kerberos failures. (ZEN-25700)
- Added Auth event clears, getPingStatus includes /Status/Ping event class. (ZEN-25700)
- Fix Windows Shell Datasources are sending datamaps and bogging down ZenHub. (ZEN-26226)

https://github.com/zenoss/ZenPacks.zenoss.Microsoft.Windows/compare/2.6.8...2.6.11