### PR TITLE
Update ZenPackLib ZenPack: hotfix/2.0.1 to master

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -203,10 +203,7 @@
         "name": "ZenPacks.zenoss.ZenOperatorRole",
         "type": "zenpack"
     },{
-        "git_ref": "hotfix/2.0.1",
         "name": "ZenPacks.zenoss.ZenPackLib",
-        "pre": true,
-        "requirement": "ZenPacks.zenoss.ZenPackLib==2.0.*",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ZenSQLTx",


### PR DESCRIPTION
Back to referencing the latest stable ZenPackLib release now that the
2.0.1 hotfix has been released.