### PR TITLE
Update ZenPackLib ZenPack: 2.0.0 to 2.0.1 (5.2.x)

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -268,10 +268,8 @@
         "requirement": "ZenPacks.zenoss.ZenOperatorRole===2.1.0",
         "type": "zenpack"
     },{
-        "git_ref": "hotfix/2.0.1",
         "name": "ZenPacks.zenoss.ZenPackLib",
-        "pre": true,
-        "requirement": "ZenPacks.zenoss.ZenPackLib==2.0.*",
+        "requirement": "ZenPacks.zenoss.ZenPackLib===2.0.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ZenSQLTx",


### PR DESCRIPTION
Changes from 2.0.0 to 2.0.1:

- Ensure all datapoint attributes export to YAML (ZEN-26593)
- Ensure subsquent installations complete if ZP install fails (ZPS-627)
- Fixes for unit test failures in platform integration tests.

https://github.com/zenoss/ZenPacks.zenoss.ZenPackLib/compare/2.0.0...2.0.1