### PR TITLE
Update CiscoUCS ZenPack: 2.5.4 to 2.5.5

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -41,7 +41,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCS",
-        "requirement": "ZenPacks.zenoss.CiscoUCS===2.5.4",
+        "requirement": "ZenPacks.zenoss.CiscoUCS===2.5.5",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCSCentral",


### PR DESCRIPTION
Changes from 2.5.4 to 2.5.5:

- Fix warnings in modeling results. (ZPS-645)
- Fix CIMC "Maximum sessions reached" error. (ZPS-227)

https://github.com/zenoss/ZenPacks.zenoss.CiscoUCS/compare/2.5.4...2.5.5