### PR TITLE
Add more info when queries to zenosslabs fail

### DIFF
--- a/artifact_download.py
+++ b/artifact_download.py
@@ -96,14 +96,19 @@ def zenpackDownload(versionInfo, outdir, downloadReport):
         }
 
         downloadReport.append(artifactInfo)
-        raise
+        raise Exception("Error querying for ZP info from %s: %s" % (url, e))
+    except urllib2.URLError as e:
+        artifactInfo["zenpack"] = {
+            "error": str(e),
+        }
+        downloadReport.append(artifactInfo)
+        raise Exception("Error querying for ZP info from %s: %s" % (url, e))
     except Exception as e:
         artifactInfo["zenpack"] = {
             "error": str(e),
         }
-
         downloadReport.append(artifactInfo)
-        raise
+        raise Exception("Error querying for ZP info from %s: %s" % (url, e))
 
     # Include unaltered response under "zenpack" key in download report.
     artifactInfo["zenpack"] = zenpack


### PR DESCRIPTION
Helpful for expedited debugging of error messages like this from http://platform-jenkins.zenoss.eng/job/product-assembly/job/develop/job/resmgr-pipeline/65:
```
Traceback (most recent call last):
  File "../artifact_download.py", line 577, in <module>
    main(options)
  File "../artifact_download.py", line 329, in main
    downloadArtifacts(options.versions, artifacts, options.out_dir, downloadReport)
  File "../artifact_download.py", line 274, in downloadArtifacts
    downloaders[versionInfo['type']](versionInfo, downloadDir, downloadReport)
  File "../artifact_download.py", line 90, in zenpackDownload
    zenpack = json.loads(urllib2.urlopen(url).read())
  File "/usr/lib64/python2.7/urllib2.py", line 154, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib64/python2.7/urllib2.py", line 437, in open
    response = meth(req, response)
  File "/usr/lib64/python2.7/urllib2.py", line 550, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib64/python2.7/urllib2.py", line 475, in error
    return self._call_chain(*args)
  File "/usr/lib64/python2.7/urllib2.py", line 409, in _call_chain
    result = func(*args)
  File "/usr/lib64/python2.7/urllib2.py", line 558, in http_error_default
    raise HTTPError(req.get_full_url(), code, msg, hdrs, fp)
urllib2.HTTPError: HTTP Error 500: Internal Server Error
```