### PR TITLE
fixes ZEN-26723: Upgrade scripts contain wrong image tag reference

### DIFF
--- a/core/upgrade-core.txt.in
+++ b/core/upgrade-core.txt.in
@@ -27,7 +27,7 @@ REQUIRE_SVC
 SNAPSHOT preupgrade-core-%VERSION%
 
 # Choose image to upgrade to
-SVC_USE zenoss/core_%SHORT_VERSION%:%VERSION% zenoss/core_5.0 zenoss/core_5.1 zenoss/core_5.2
+SVC_USE zenoss/core_%SHORT_VERSION%:%VERSION%_%VERSION_TAG% zenoss/core_5.0 zenoss/core_5.1 zenoss/core_5.2
 SVC_USE zenoss/hbase:%HBASE_VERSION%
 SVC_USE zenoss/opentsdb:%OPENTSDB_VERSION%
 

--- a/resmgr/upgrade-resmgr.txt.in
+++ b/resmgr/upgrade-resmgr.txt.in
@@ -27,7 +27,7 @@ REQUIRE_SVC
 SNAPSHOT preupgrade-resmgr-%VERSION%
 
 # Choose image to upgrade to
-SVC_USE zenoss/resmgr_%SHORT_VERSION%:%VERSION% zenoss/resmgr_5.0 zenoss/resmgr_5.1 zenoss/resmgr_5.2
+SVC_USE zenoss/resmgr_%SHORT_VERSION%:%VERSION%_%VERSION_TAG% zenoss/resmgr_5.0 zenoss/resmgr_5.1 zenoss/resmgr_5.2
 SVC_USE zenoss/hbase:%HBASE_VERSION%
 SVC_USE zenoss/opentsdb:%OPENTSDB_VERSION%
 

--- a/ucspm/upgrade-ucspm.txt.in
+++ b/ucspm/upgrade-ucspm.txt.in
@@ -27,7 +27,7 @@ REQUIRE_SVC
 SNAPSHOT preupgrade-ucspm-%VERSION%
 
 # Choose image to upgrade to
-SVC_USE zenoss/ucspm_%SHORT_VERSION%:%VERSION% zenoss/ucspm_5.1 zenoss/ucspm_5.2
+SVC_USE zenoss/ucspm_%SHORT_VERSION%:%VERSION%_%VERSION_TAG% zenoss/ucspm_5.1 zenoss/ucspm_5.2
 SVC_USE zenoss/hbase:%HBASE_VERSION%
 SVC_USE zenoss/opentsdb:%OPENTSDB_VERSION%
 

--- a/versions.mk
+++ b/versions.mk
@@ -18,6 +18,7 @@ SHORT_VERSION=5.2
 SVCDEF_GIT_REF=support/5.2.x
 VERSION=5.2.1
 UCSPM_VERSION=2.1.0
+VERSION_TAG=1
 
 #
 # Currently, HDFS and OpenTSDB use the same image as HBASE


### PR DESCRIPTION
original fix: #212