### PR TITLE
Get zep artifacts from jenkins

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -56,10 +56,11 @@
         "version": "2.1.4-1"
     },
     {
-        "URL": "http://zenpip.zendev.org/packages/zep-dist-{version}.tar.gz",
         "name": "zenoss-zep",
-        "type": "download",
-        "version": "2.2.2"
+        "type": "jenkins",
+        "jenkins.server": "http://platform-jenkins.zenoss.eng",
+        "jenkins.job": "Components/job/zenoss-zep/job/develop",
+        "version": "develop"
     },
     {
         "URL": "http://zenpip.zendev.org/packages/metric-consumer-app-{version}-zapp.tar.gz",


### PR DESCRIPTION
A unit test of zep was revised so as to pass when it's run on devimg. To refelect this change, get zep artifacts from jenkins instead of dowloading from zenpip.