### PR TITLE
Fix version info for CC ZenPack

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -53,7 +53,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ControlCenter",
-        "requirement": "ZenPacks.zenoss.ControlCenter===1.5.*",
+        "requirement": "ZenPacks.zenoss.ControlCenter",
         "type": "zenpack",
         "pre": true
     },{


### PR DESCRIPTION
Fixes the build problem:
```
Traceback (most recent call last):
  File "../artifact_download.py", line 581, in <module>
    main(options)
  File "../artifact_download.py", line 333, in main
    downloadArtifacts(options.versions, artifacts, options.out_dir, downloadReport)
  File "../artifact_download.py", line 278, in downloadArtifacts
    downloaders[versionInfo['type']](versionInfo, downloadDir, downloadReport)
  File "../artifact_download.py", line 99, in zenpackDownload
    raise Exception("Error querying for ZP info from %s: %s" % (url, e))
Exception: Error querying for ZP info from http://zenpacks.zenosslabs.com/requirement/ZenPacks.zenoss.ControlCenter%3D%3D%3D1.5.%2A?pre: HTTP Error 404: Not Found
make: *** [zenpack_download] Error 1
```
from build http://platform-jenkins.zenoss.eng/job/product-assembly/job/support-5.2.x/job/resmgr-pipeline/