### PR TITLE
ZEN-26723: add VERSION_TAG to impact upgrade script and missing sed

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -37,7 +37,7 @@ getDownloadLogs:
 	docker run --rm -v $(PWD):/mnt/export -t $(TAG) rsync -a /opt/zenoss/log/zenoss_component_artifact.log /opt/zenoss/log/zenpacks_artifact.log /mnt/export
 
 upgrade-%.txt:
-	@sed -e 's/%HBASE_VERSION%/$(HBASE_VERSION)/g; s/%OPENTSDB_VERSION%/$(OPENTSDB_VERSION)/g; s/%SHORT_VERSION%/$(SHORT_VERSION)/g; s/%VERSION%/$(VERSION)/g; s/%RELEASE_PHASE%/$(MATURITY)/g; ' upgrade-$*.txt.in > $@
+	@sed -e 's/%HBASE_VERSION%/$(HBASE_VERSION)/g; s/%OPENTSDB_VERSION%/$(OPENTSDB_VERSION)/g; s/%SHORT_VERSION%/$(SHORT_VERSION)/g; s/%VERSION%/$(VERSION)/g; s/%RELEASE_PHASE%/$(MATURITY)/g; s/%VERSION_TAG%/$(VERSION_TAG)/g;' upgrade-$*.txt.in > $@
 
 upgrade-%.sh:
 	@sed -e 's/%SHORT_VERSION%/$(SHORT_VERSION)/g; s/%VERSION%/$(VERSION)/g;' upgrade-$*.sh.in > $@

--- a/resmgr/upgrade-impact.txt.in
+++ b/resmgr/upgrade-impact.txt.in
@@ -27,7 +27,7 @@ REQUIRE_SVC
 SNAPSHOT preupgrade-resmgr-%VERSION%
 
 # Choose image to upgrade to
-SVC_USE zenoss/resmgr_%SHORT_VERSION%:%VERSION% zenoss/resmgr_5.0 zenoss/resmgr_5.1 zenoss/resmgr_5.2
+SVC_USE zenoss/resmgr_%SHORT_VERSION%:%VERSION%_%VERSION_TAG% zenoss/resmgr_5.0 zenoss/resmgr_5.1 zenoss/resmgr_5.2
 SVC_USE zenoss/hbase:%HBASE_VERSION%
 SVC_USE zenoss/opentsdb:%OPENTSDB_VERSION%
 


### PR DESCRIPTION
This is port from: https://github.com/zenoss/product-assembly/pull/235

[JIRA](https://jira.zenoss.com/browse/ZEN-26723)