### PR TITLE
Update ZenPackLib ZenPack: hotfix/2.0.2 to 2.0.2

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -270,9 +270,7 @@
     },{
         "name": "ZenPacks.zenoss.ZenPackLib",
         "type": "zenpack",
-        "requirement": "ZenPacks.zenoss.ZenPackLib==2.0.*",
-        "git_ref": "hotfix/2.0.2",
-        "pre": true
+        "requirement": "ZenPacks.zenoss.ZenPackLib===2.0.2"
     },{
         "name": "ZenPacks.zenoss.ZenSQLTx",
         "requirement": "ZenPacks.zenoss.ZenSQLTx===2.6.5",


### PR DESCRIPTION
Changes from 2.0.1 to 2.0.2:

- Only create a monitoring template if it changes or does not exist (ZPS-570)
- Ensure display of ZPL classes such as OSProcess in GUI elements (ZPS-572, ZPS-651)

https://github.com/zenoss/ZenPacks.zenoss.ZenPackLib/compare/2.0.1...2.0.2