### PR TITLE
Update ZenPackLib ZenPack: hotfix/2.0.2 to latest

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -208,10 +208,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ZenPackLib",
-        "type": "zenpack",
-        "requirement": "ZenPacks.zenoss.ZenPackLib==2.0.*",
-        "git_ref": "hotfix/2.0.2",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ZenSQLTx",
         "type": "zenpack"


### PR DESCRIPTION
Restoring ZenPackLib to latest stable release. Testing of the 2.0.2
hotfix has been finished.