### PR TITLE
Ignore 'sh' nodes in the stage flow

### DIFF
--- a/build_status.py
+++ b/build_status.py
@@ -388,6 +388,13 @@ def addChildJobs(templates, stage, jobs):
         (len(stageFlowInfo["stageFlowNodes"]), stage["name"]))
 
     for node in stageFlowInfo["stageFlowNodes"]:
+        # This is a bit of a hack - the finally clause in Jenkins-begin.groovy
+        #    is included in the stageFlowNodes, so the following excludes it
+        #    and any other simple 'sh()' directives that may be added in the
+        #   future.
+        if node["name"] == "Shell Script":
+            continue
+
         names = node["name"].split()
         jobName = names[len(names)-1]
 


### PR DESCRIPTION
Fixes cases like the failure in build 116 which was caused by the fact that the list of stage nodes for 'Run all product pipelines' included a 'Shell Script' node representing the `finally` block in the `Jenkins-begin.groovy` script.

Here's the link to the description of the begin job itself http://platform-jenkins.zenoss.eng/job/product-assembly/job/develop/job/begin/116/wfapi/describe

If you look at the last entry for the `stages` property,  you will find this reference for details about the 'Run all product pipelines' stage - 
http://platform-jenkins.zenoss.eng/job/product-assembly/job/develop/job/begin/116/execution/node/15/wfapi/describe

If you look at the `stageFlowNodes` in that link, you will that the first 2 entries represent the `appliance-build` jobs, and the last entry named `Shell Script` is the one that through off the status report.   If you then look at the log link for that last entry - http://platform-jenkins.zenoss.eng/job/product-assembly/job/develop/job/begin/116/execution/node/25/wfapi/log
 you will see that it's logging the execution of the `build-status.py` as defined in the `finally` block of `Jenkins-begin.groovy`