### PR TITLE
More fixup for build_status.py

### DIFF
--- a/build_status.py
+++ b/build_status.py
@@ -392,7 +392,7 @@ def addChildJobs(templates, stage, jobs):
         #    is included in the stageFlowNodes, so the following excludes it
         #    and any other simple 'sh()' directives that may be added in the
         #   future.
-        if node["name"] == "Shell Script":
+        if not node["name"].startswith("Building "):
             continue
 
         names = node["name"].split()


### PR DESCRIPTION
Trying again to ignore unexpected stages that appear when a job is cancelled.

In this case, aborting a downstream job triggered the execution flow for `Jenkins-begin.groovy` to execute that `catch` block which included a print statement that resulted in a `Print message` node in the stage details.  See http://platform-jenkins.zenoss.eng/job/product-assembly/job/develop/job/begin/

So this time, I ignore all stages for child jobs unless they begin with "Building " 