### PR TITLE
Identify different types of aborted-job messages

### DIFF
--- a/Jenkins-begin.groovy
+++ b/Jenkins-begin.groovy
@@ -61,7 +61,8 @@ node ('build-zenoss-product') {
             parallel branches
     } catch (err) {
         echo "Job failed with the following error: ${err}"
-        if (err.toString().contains("hudson.AbortException:")) {
+        if (err.toString().contains("completed with status ABORTED") ||
+            err.toString().contains("hudson.AbortException: script returned exit code 2")) {
             currentBuild.result = 'ABORTED'
         } else {
             currentBuild.result = 'FAILED'


### PR DESCRIPTION
Trying to correct the ambiguity in situations like this where the build actually failed, but the summary status in the HTML report was "ABORTED":
http://platform-jenkins.zenoss.eng/job/product-assembly/job/develop/job/begin/119/Build_Summary_Report/

Contrary to what I first thought, `hudson.AbortException` is issued both in cases where the `begin` job is aborted by the user, AND in cases when the downstream jobs fail. So this change is an attempt to be more selective in parsing the results.