### PR TITLE
Workarounds for reporting while job is not finished

### DIFF
--- a/Jenkins-begin.groovy
+++ b/Jenkins-begin.groovy
@@ -59,6 +59,9 @@ node ('build-zenoss-product') {
             ]
 
             parallel branches
+            // Set the status to success because the finally block is about to execute
+            //      and we don't want the final report status to be "IN-PROGRESS"
+            currentBuild.result = 'SUCCESS'
     } catch (err) {
         echo "Job failed with the following error: ${err}"
         if (err.toString().contains("completed with status ABORTED") ||

--- a/build_status.py
+++ b/build_status.py
@@ -489,17 +489,13 @@ def buildJobHTML(job, level):
     else:
         jobLink = job.jenkinsInfo.label
     duration = print_duration(job.timeStats.duration) if job.timeStats and job.timeStats.duration else ""
-    status = job.jenkinsInfo.status if job.jenkinsInfo and job.jenkinsInfo.status else ""
-    if status and status != "SUCCESS":
-        statusClass = "failure"
-    else:
-        statusClass = "success"
+    status = job.jenkinsInfo.status if job.jenkinsInfo and validStatus(job.jenkinsInfo.status) else ""
 
     row = ROW_TEMPLATE.safe_substitute(
         indentLevel=indentLevel,
         name=jobLink,
         status=status,
-        statusClass=statusClass,
+        statusClass=setStatusClass(status),
         duration=duration)
     jobRows.append(str(row))
 
@@ -514,17 +510,13 @@ def buildStageHTML(stage, level):
     stageRows = []
     indentLevel = "indent%d" % level
     duration = print_duration(stage.timeStats.duration) if stage.timeStats and stage.timeStats.duration else ""
-    status = stage.status if stage.status else ""
-    if status and status != "SUCCESS":
-        statusClass = "failure"
-    else:
-        statusClass = "success"
+    status = stage.status if validStatus(stage.status) else ""
 
     row = ROW_TEMPLATE.substitute(
         indentLevel=indentLevel,
         name=stage.name,
         status=status,
-        statusClass=statusClass,
+        statusClass=setStatusClass(status),
         duration=duration)
     stageRows.append(str(row))
 
@@ -534,8 +526,28 @@ def buildStageHTML(stage, level):
 
     return stageRows
 
+
+# When this report is called from the finally block of job, some of the
+#   jobs/stages might technically still be IN_PROGRESS because the
+#   parent job is not really done until the finally block finishes.
+#   Reporting "in progress" for the last stage is potentially confusing,
+#   so don't report anything at all in that case.
+#
+# Note that if the report is run after the parent job has completly finished
+#   then we'll never encounter a status of IN_PROGRESS
+def validStatus(status):
+    return status and status != "IN_PROGRESS"
+
+
+def setStatusClass(status):
+    if status and status != "SUCCESS":
+        return "failure"
+    return "success"
+
+
 ONE_HOUR = 3600
 ONE_MINUTE = 60
+
 
 def print_duration(duration):
   elapsed = datetime.timedelta(0, 0, 0, duration)


### PR DESCRIPTION
There are 2 problems in http://platform-jenkins.zenoss.eng/job/product-assembly/job/develop/job/begin/121/Build_Summary_Report/

Both have to do with the fact that when Jenkins executes the report script in the `finally` block, the `begin` job is not done - it's still an active running job.

1. The summary status for the `begin` job is "null". This is because when `currentBuild.status` was not set in the case of a successful job completion
2. The stage "Run all product pipelines" has an `IN_PROGRESS` status. This is potentially confusing.  Without doing more analysis of all of the child jobs/stages, it's difficult to know if the final status is SUCCESS or FAILURE, therefore just don't set the status field for stages or jobs which report `IN_PROGRESS`.