### PR TITLE
Replace SERVICED_BUILD_NBR with SERVICED_BUILD_NUMBER

### DIFF
--- a/Jenkins-image.groovy
+++ b/Jenkins-image.groovy
@@ -30,13 +30,13 @@ node ('build-zenoss-product') {
         def SERVICED_BRANCH=versionProps['SERVICED_BRANCH']
         def SERVICED_MATURITY=versionProps['SERVICED_MATURITY']
         def SERVICED_VERSION=versionProps['SERVICED_VERSION']
-        def SERVICED_BUILD_NBR=versionProps['SERVICED_BUILD_NBR']
+        def SERVICED_BUILD_NUMBER=versionProps['SERVICED_BUILD_NUMBER']
         echo "SVCDEF_GIT_REF=${SVCDEF_GIT_REF}"
         echo "ZENOSS_VERSION=${ZENOSS_VERSION}"
         echo "SERVICED_BRANCH=${SERVICED_BRANCH}"
         echo "SERVICED_MATURITY=${SERVICED_MATURITY}"
         echo "SERVICED_VERSION=${SERVICED_VERSION}"
-        echo "SERVICED_BUILD_NBR=${SERVICED_BUILD_NBR}"
+        echo "SERVICED_BUILD_NUMBER=${SERVICED_BUILD_NUMBER}"
 
         // Make the target product
         sh("cd ${TARGET_PRODUCT};MATURITY=${MATURITY} BUILD_NUMBER=${PRODUCT_BUILD_NUMBER} make clean build getDownloadLogs")
@@ -109,7 +109,7 @@ node ('build-zenoss-product') {
                             [$class: 'StringParameterValue', name: 'SERVICED_BRANCH', value: SERVICED_BRANCH],
                             [$class: 'StringParameterValue', name: 'SERVICED_MATURITY', value: SERVICED_MATURITY],
                             [$class: 'StringParameterValue', name: 'SERVICED_VERSION', value: SERVICED_VERSION],
-                            [$class: 'StringParameterValue', name: 'SERVICED_BUILD_NBR', value: SERVICED_BUILD_NBR],
+                            [$class: 'StringParameterValue', name: 'SERVICED_BUILD_NUMBER', value: SERVICED_BUILD_NUMBER],
                     ]
                 }
 
@@ -127,7 +127,7 @@ node ('build-zenoss-product') {
                         [$class: 'StringParameterValue', name: 'SERVICED_BRANCH', value: SERVICED_BRANCH],
                         [$class: 'StringParameterValue', name: 'SERVICED_MATURITY', value: SERVICED_MATURITY],
                         [$class: 'StringParameterValue', name: 'SERVICED_VERSION', value: SERVICED_VERSION],
-                        [$class: 'StringParameterValue', name: 'SERVICED_BUILD_NBR', value: SERVICED_BUILD_NBR],
+                        [$class: 'StringParameterValue', name: 'SERVICED_BUILD_NUMBER', value: SERVICED_BUILD_NUMBER],
                 ]
             }
         }

--- a/Jenkins-promote.groovy
+++ b/Jenkins-promote.groovy
@@ -49,14 +49,14 @@ node ('build-zenoss-product') {
         def SERVICED_BRANCH=versionProps['SERVICED_BRANCH']
         def SERVICED_MATURITY=versionProps['SERVICED_MATURITY']
         def SERVICED_VERSION=versionProps['SERVICED_VERSION']
-        def SERVICED_BUILD_NBR=versionProps['SERVICED_BUILD_NBR']
+        def SERVICED_BUILD_NUMBER=versionProps['SERVICED_BUILD_NUMBER']
         echo "SVCDEF_GIT_REF=${SVCDEF_GIT_REF}"
         echo "ZENOSS_VERSION=${ZENOSS_VERSION}"
         echo "ZENOSS_SHORT_VERSION=${ZENOSS_SHORT_VERSION}"
         echo "SERVICED_BRANCH=${SERVICED_BRANCH}"
         echo "SERVICED_MATURITY=${SERVICED_MATURITY}"
         echo "SERVICED_VERSION=${SERVICED_VERSION}"
-        echo "SERVICED_BUILD_NBR=${SERVICED_BUILD_NBR}"
+        echo "SERVICED_BUILD_NUMBER=${SERVICED_BUILD_NUMBER}"
 
         // Promote the docker images
         def promoteArgs = "TARGET_PRODUCT=${TARGET_PRODUCT}\
@@ -132,7 +132,7 @@ node ('build-zenoss-product') {
                             [$class: 'StringParameterValue', name: 'SERVICED_BRANCH', value: SERVICED_BRANCH],
                             [$class: 'StringParameterValue', name: 'SERVICED_MATURITY', value: SERVICED_MATURITY],
                             [$class: 'StringParameterValue', name: 'SERVICED_VERSION', value: SERVICED_VERSION],
-                            [$class: 'StringParameterValue', name: 'SERVICED_BUILD_NBR', value: SERVICED_BUILD_NBR],
+                            [$class: 'StringParameterValue', name: 'SERVICED_BUILD_NUMBER', value: SERVICED_BUILD_NUMBER],
                     ]
                 }
 
@@ -150,7 +150,7 @@ node ('build-zenoss-product') {
                         [$class: 'StringParameterValue', name: 'SERVICED_BRANCH', value: SERVICED_BRANCH],
                         [$class: 'StringParameterValue', name: 'SERVICED_MATURITY', value: SERVICED_MATURITY],
                         [$class: 'StringParameterValue', name: 'SERVICED_VERSION', value: SERVICED_VERSION],
-                        [$class: 'StringParameterValue', name: 'SERVICED_BUILD_NBR', value: SERVICED_BUILD_NBR],
+                        [$class: 'StringParameterValue', name: 'SERVICED_BUILD_NUMBER', value: SERVICED_BUILD_NUMBER],
                 ]
             }
         }

--- a/versions.mk
+++ b/versions.mk
@@ -39,21 +39,21 @@ OPENTSDB_VERSION=24.0.3
 #    up the last successful build for that branch to get the RPM version information necessary
 #    to install the serviced RPM from the unstable yum repo into the appliances.
 #
-#    If SERVICED_BRANCH is specified, both SERVICED_VERSION and SERVICED_BLD_NUMBER must be blank.
+#    If SERVICED_BRANCH is specified, both SERVICED_VERSION and SERVICED_BUILD_NUMBER must be blank.
 #
 # 2. Specify a specific version and build
 #
 #    Specify the 3-digit version of serviced with SERVICED_VERSION and the build number with
-#    SERVICE_BUILD_NBR. The corresponding RPM must be available in the stable yum repo.
+#    SERVICED_BUILD_NUMBER. The corresponding RPM must be available in the stable yum repo.
 #
-#    SERVICED_VERSION and SERVICED_BLD_NUMBER have to be specified together, and
+#    SERVICED_VERSION and SERVICED_BUILD_NUMBER have to be specified together, and
 #    SERVICED_BRANCH must be blank if both are specified.
 #
 #    If SERVICED_BRANCH is specified, then SERVICED_MATURITY must be 'unstable'.
-#    If SERVICED_VERSION and SERVICED_BUILD_NBR are specified, then the
+#    If SERVICED_VERSION and SERVICED_BUILD_NUMBER are specified, then the
 #    SERVICED_BRANCH should be 'testing' or 'stable'
 #
 SERVICED_BRANCH=develop
 SERVICED_MATURITY=unstable
 SERVICED_VERSION=
-SERVICED_BUILD_NBR=
+SERVICED_BUILD_NUMBER=


### PR DESCRIPTION
Fixes an integration problem btwn the code in product-assembly and the code in zenoss-deploy.

The Jenkins job and the groovy scripts in zenoss-deploy expect a parameter named `SERVICED_BUILD_NUMBER` but the scripts in product-asembly were passing a parameter named`SERVICED_BUILD_NBR`

The build number for serviced is only used when building appliances that should include a GA version of serviced. Since this happens only occasionally, that's why this problem was missed.
This discrepancy was introduced after 5.2.0 was released. We didn't see it for the 5.2.1 release because one-off procedures were used during that release process.
