### PR TITLE
ZEN-27044 manifest change for central-query

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -20,7 +20,7 @@
         "name": "query",
         "type": "jenkins",
         "version": "develop"
-        },
+    },
     {
         "URL": "http://zenpip.zendev.org/packages/{name}-{version}.tgz",
         "name": "redis-mon",

--- a/component_versions.json
+++ b/component_versions.json
@@ -20,7 +20,7 @@
         "URL": "http://zenpip.zendev.org/packages/central-query-{version}-zapp.tar.gz",
         "name": "query",
         "type": "download",
-        "version": "0.1.16"
+        "version": "develop"
     },
     {
         "URL": "http://zenpip.zendev.org/packages/{name}-{version}.tgz",

--- a/component_versions.json
+++ b/component_versions.json
@@ -17,11 +17,10 @@
         "version": "0.40.6"
     },
     {
-        "URL": "http://zenpip.zendev.org/packages/central-query-{version}-zapp.tar.gz",
         "name": "query",
-        "type": "download",
+        "type": "jenkins",
         "version": "develop"
-    },
+        },
     {
         "URL": "http://zenpip.zendev.org/packages/{name}-{version}.tgz",
         "name": "redis-mon",


### PR DESCRIPTION
Central query was pinned to v1.16 for the Metis release. Reverting the assembly build manifest for the 5.2.x central-query build to pull from central-query develop branch until Thebe release when central-query will be reversioned.