### PR TITLE
Add DurationThreshold ZenPack

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -72,6 +72,9 @@
         "name": "ZenPacks.zenoss.DnsMonitor",
         "type": "zenpack"
     },{
+        "name": "ZenPacks.zenoss.DurationThreshold",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.DynamicView",
         "type": "zenpack"
     },{


### PR DESCRIPTION
Adding DurationThreshold to help ensure that customers using it get the
latest version needed to be compatible with the contextMetric change
introduced by ZEN-27003.

Fixes ZEN-27018.