### PR TITLE
Fix order of zenpack installation output

### DIFF
--- a/product-base/install_scripts/zp_install.py
+++ b/product-base/install_scripts/zp_install.py
@@ -31,13 +31,13 @@ def main(args):
             raise Exception("Found multiple files for zenpack: %s" % zpName)
         else:
             zpFile = os.path.join(args.zpDir, zpFileName[0])
-            sys.stdout.flush()
             cmd = ['zenpack', '--install', zpFile]
             if args.link:
                 print "Installing zenpack in link mode: %s %s" % (zpName, zpFile)
                 cmd.append('--link')
             else:
                 print "Installing zenpack: %s %s" % (zpName, zpFile)
+            sys.stdout.flush()
             subprocess.check_call(cmd)
 
 


### PR DESCRIPTION
Better to say we're installing a ZenPack before installing it instead of
after. It actually used to be this way, but the code around here churned
a few times and the stdout.flush() ended up inappropriately rearranged
to before the write to stdout.