### PR TITLE
5.3.0: install DurationThreshold by default

### DIFF
--- a/resmgr/zenpacks.json
+++ b/resmgr/zenpacks.json
@@ -58,6 +58,7 @@
         "ZenPacks.zenoss.Microsoft.Windows",
         "ZenPacks.zenoss.DistributedCollector",
         "ZenPacks.zenoss.ControlCenter",
+        "ZenPacks.zenoss.DurationThreshold",
         "ZenPacks.zenoss.PredictiveThreshold",
         "ZenPacks.zenoss.ComponentGroups",
         "ZenPacks.zenoss.SupportBundle"

--- a/resmgr/zphistory.json
+++ b/resmgr/zphistory.json
@@ -18,6 +18,7 @@
   "ZenPacks.zenoss.DigMonitor": "5.0.0",
   "ZenPacks.zenoss.DistributedCollector": "5.0.0",
   "ZenPacks.zenoss.DnsMonitor": "5.0.0",
+  "ZenPacks.zenoss.DurationThreshold": "5.3.0",
   "ZenPacks.zenoss.DynamicView": "5.0.0",
   "ZenPacks.zenoss.EnterpriseCollector": "5.0.0",
   "ZenPacks.zenoss.EnterpriseLinux": "5.0.0",


### PR DESCRIPTION
DON'T MERGE THIS YET! It'll break the build until another change goes in.

It's a useful threshold. We should be including it if we're including
PredictiveThreshold. Also this will help to make sure that anyone that
already has it installed will get the required update to make it
compatible with the contextMetric change.

Refs ZEN-27018.