### PR TITLE
Update CalculatedPerformance ZenPack: 2.3.0 to 2.3.2

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -25,7 +25,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CalculatedPerformance",
-        "requirement": "ZenPacks.zenoss.CalculatedPerformance===2.3.0",
+        "requirement": "ZenPacks.zenoss.CalculatedPerformance===2.3.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CatalogService",


### PR DESCRIPTION
Changes from 2.3.0 to 2.3.2:

- Clarify event when aggregation operation is blank or invalid. (ZPS-71)
- Change default aggregation operation from blank to "sum". (ZPS-71)
- Support new contextMetric capability in Zenoss 5.2.3. (ZEN-27010)

https://github.com/zenoss/ZenPacks.zenoss.CalculatedPerformance/compare/2.3.0...2.3.2