### PR TITLE
Add DurationThreshold ZenPack

### DIFF
--- a/resmgr/zenpacks.json
+++ b/resmgr/zenpacks.json
@@ -57,6 +57,7 @@
         "ZenPacks.zenoss.Microsoft.Windows",
         "ZenPacks.zenoss.DistributedCollector",
         "ZenPacks.zenoss.ControlCenter",
+        "ZenPacks.zenoss.DurationThreshold",
         "ZenPacks.zenoss.PredictiveThreshold",
         "ZenPacks.zenoss.ComponentGroups",
         "ZenPacks.zenoss.SupportBundle"

--- a/resmgr/zphistory.json
+++ b/resmgr/zphistory.json
@@ -18,6 +18,7 @@
   "ZenPacks.zenoss.DigMonitor": "5.0.0",
   "ZenPacks.zenoss.DistributedCollector": "5.0.0",
   "ZenPacks.zenoss.DnsMonitor": "5.0.0",
+  "ZenPacks.zenoss.DurationThreshold": "5.2.3",
   "ZenPacks.zenoss.DynamicView": "5.0.0",
   "ZenPacks.zenoss.EnterpriseCollector": "5.0.0",
   "ZenPacks.zenoss.EnterpriseLinux": "5.0.0",

--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -88,6 +88,10 @@
         "requirement": "ZenPacks.zenoss.DnsMonitor===2.1.0",
         "type": "zenpack"
     },{
+        "name": "ZenPacks.zenoss.DurationThreshold",
+        "requirement": "ZenPacks.zenoss.DurationThreshold===2.0.2",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.DynamicView",
         "requirement": "ZenPacks.zenoss.DynamicView===1.5.0",
         "type": "zenpack"


### PR DESCRIPTION
DON'T MERGE THIS YET! It'll break the build until another change goes in.

Adding DurationThreshold to help ensure that customers using it get the
latest version needed to be compatible with the contextMetric change
introduced by ZEN-27003.

Installing by default because it's a useful threshold. We should be
including it if we're including PredictiveTreshold.

Fixes ZEN-27018.