### PR TITLE
Update PredictiveThreshold ZenPack: 1.2.0 to 1.2.1

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -191,7 +191,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.PredictiveThreshold",
-        "requirement": "ZenPacks.zenoss.PredictiveThreshold===1.2.0",
+        "requirement": "ZenPacks.zenoss.PredictiveThreshold===1.2.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.PortalIntegration",


### PR DESCRIPTION
Changes from 1.2.0 to 1.2.1:

- Support new contextMetric capability in Zenoss 5.2.3. (ZEN-27011)

https://github.com/zenoss/ZenPacks.zenoss.PredictiveThreshold/compare/1.2.0...1.2.1