### PR TITLE
Update EnterpriseReports ZenPack: 2.4.0 to 2.4.1

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -101,7 +101,7 @@
         "pre": true
     },{
         "name": "ZenPacks.zenoss.EnterpriseReports",
-        "requirement": "ZenPacks.zenoss.EnterpriseReports===2.4.0",
+        "requirement": "ZenPacks.zenoss.EnterpriseReports===2.4.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.EnterpriseSecurity",


### PR DESCRIPTION
Changes from 2.4.0 to 2.4.1:

- Support new contextMetric capability in Zenoss 5.2.3. (ZEN-27009)

https://github.com/zenoss/ZenPacks.zenoss.EnterpriseReports/compare/2.4.0...2.4.1