### PR TITLE
Update vSphere ZenPack: 3.5.3 to 3.6.1

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -235,7 +235,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.vSphere",
-        "requirement": "ZenPacks.zenoss.vSphere===3.5.3",
+        "requirement": "ZenPacks.zenoss.vSphere===3.6.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.WBEM",


### PR DESCRIPTION
Changes from 3.5.3 to 3.6.1:

- Analytics: Count vSphere devices in overall device inventory (add to dim_device) (ZPS-398)
- Fix improperly rounded 'Total' value on 'Performance Data Collection Counters' graph (ZPS-392)
- Fix calculation of missedRuns in zenvsphere by not counting event and modeler tasks (they are run constantly, and can never be 'late') (ZPS-399)
- Fix error while displaying VMs report (ZPS-337)
- Remove broken 'folder' links from component details (ZPS-396)
- Clarify resource pool counts on Datacenter components (ZPS-389)
- Suppress events when vSphere host is in maintenance mode (by setting Host and VM productionState accordingly) (ZPS-332)
- Fix modeling errors with VMs that are inside nested resource pools within vApps (ZPS-387)
- Updated to zenpacklib 1.1.2.
- Added zVSphereHostPingWhitelist and zVSphereHostPingBlacklist to control selection of management IPs to ping (ZPS-335)
- Modeler suppresses objects which should not be modeled, including references from other objects. Support added for "effectiveRole" based filtering to exclude VMs from the model if the user has the NoAccess role on the host or cluster that the VM is hosted on. Fix suppression-related issues for LUNs and VM Templates. (ZEN-22233, ZEN-21904, ZEN-25884, ZEN-25625)
- Fix modeling of certain datastores on ESX endpoints (ZPS-512)
- Alarms missing descriptions ("Alarm_alarm-123 status is red") on vSphere 6.0 targets (ZPS-397)
- Support monitoring of disk usage on datastores on ESX endpoints (ZPS-504). ZenPacks.zenoss.PropertyMonitor &gt;= 1.1.1 is required for this. 1.1.0 is sufficient for vCenter endpoints.
- Support for vSphere 6.5
- Support new contextMetric capability in Zenoss 5.2.3. (ZEN-27004)

https://github.com/zenoss/ZenPacks.zenoss.vSphere/compare/3.5.3...3.6.1