### PR TITLE
Package DurationThreshold 2.0.2 (not installed)

### DIFF
--- a/resmgr/zenpacks.json
+++ b/resmgr/zenpacks.json
@@ -63,6 +63,7 @@
         "ZenPacks.zenoss.SupportBundle"
     ],
     "included_not_installed": [
+        "ZenPacks.zenoss.DurationThreshold",
         "ZenPacks.zenoss.NetScaler"
     ],
     "version_overrides": {}


### PR DESCRIPTION
DurationThreshold must be packaged with resmgr as of 5.3.0 to ensure
customers already using it get the DurationThreshold 2.0.2 upgrade
required for compatibility with contextMetric (ZEN-27003) support going
into Zenoss 5.3.0.

Fixes ZEN-27018 for Zenoss 5.3.0.