### PR TITLE
Package DurationThreshold 2.0.2 (not installed)

### DIFF
--- a/resmgr/zenpacks.json
+++ b/resmgr/zenpacks.json
@@ -62,6 +62,7 @@
         "ZenPacks.zenoss.SupportBundle"
     ],
     "included_not_installed": [
+        "ZenPacks.zenoss.DurationThreshold",
         "ZenPacks.zenoss.NetScaler"
     ],
     "version_overrides": {}

--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -88,6 +88,10 @@
         "requirement": "ZenPacks.zenoss.DnsMonitor===2.1.0",
         "type": "zenpack"
     },{
+        "name": "ZenPacks.zenoss.DurationThreshold",
+        "requirement": "ZenPacks.zenoss.DurationThreshold===2.0.2",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.DynamicView",
         "requirement": "ZenPacks.zenoss.DynamicView===1.5.0",
         "type": "zenpack"


### PR DESCRIPTION
DurationThreshold must be packaged with resmgr as of 5.2.3 to ensure
customers already using it get the DurationThreshold 2.0.2 upgrade
required for compatibility with contextMetric (ZEN-27003) support going
into Zenoss 5.2.3.

Fixes ZEN-27018 for Zenoss 5.2.3.