### PR TITLE
Update vSphere ZenPack: 3.6.1 to 3.6.2

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -239,7 +239,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.vSphere",
-        "requirement": "ZenPacks.zenoss.vSphere===3.6.1",
+        "requirement": "ZenPacks.zenoss.vSphere===3.6.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.WBEM",


### PR DESCRIPTION
Changes from 3.6.1 to 3.6.2:

- Fix zVSphereLUNContextMetric NameError in zenhub.log. (ZPS-1184)

https://github.com/zenoss/ZenPacks.zenoss.vSphere/compare/3.6.1...3.6.2