### PR TITLE
Use 1.1.6-dev of service-migration to verify ZEN-27124

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -30,11 +30,11 @@
         "version": "0.1.2"
     },
     {
-        "URL": "http://zenpip.zendev.org/packages/servicemigration-{version}-py2-none-any.whl",
-        "git_owner": "control-center",
         "name": "service-migration",
-        "type": "download",
-        "version": "1.1.5"
+        "type": "jenkins",
+        "jenkins.server": "http://jenkins.zendev.org",
+        "jenkins.job": "service-migration-develop",
+        "version": "develop"
     },
     {
         "URL": "http://zenpip.zendev.org/packages/zenoss.extjs-{version}.tar.gz",


### PR DESCRIPTION
SVC-1051 made changes to the service-migration component to prevent installation/upgrade of the incident management ZP from accidentally erasing the `Version` property on `Zenoss.resmgr`.  This change uses that modified version of the service-migration component so we can regress SVC-1051 in a build of Thebe.