### PR TITLE
Correct job name for core appliances

### DIFF
--- a/jobTemplate.json
+++ b/jobTemplate.json
@@ -77,12 +77,12 @@
 			"childTemplate": ""
 		}],
 		"instanceTemplates": [{
-			"jobPrefix": "core product",
+			"jobPrefix": "core appliance",
 			"ignoreStages": [
 				"Upgrade ISO",
 				"AMIs",
-				"Start QA Automation",
-				"QEMU/QCOWs"],
+				"QEMU/QCOWs",
+				"Start QA Automation"],
 			"parentJob": "core-pipeline"
 		}, {
 			"jobPrefix": "zsd appliance",


### PR DESCRIPTION
The build report for core appliances was not ignoring unused stages because the jobPrefix in the template didn't match the actual job name