### PR TITLE
Update ZenPackLib: 2.0.4 to 2.0.5

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -276,7 +276,7 @@
     },{
         "name": "ZenPacks.zenoss.ZenPackLib",
         "type": "zenpack",
-        "requirement": "ZenPacks.zenoss.ZenPackLib===2.0.4"
+        "requirement": "ZenPacks.zenoss.ZenPackLib===2.0.5"
     },{
         "name": "ZenPacks.zenoss.ZenSQLTx",
         "requirement": "ZenPacks.zenoss.ZenSQLTx===2.6.6",


### PR DESCRIPTION
Required by ZenPacks.zenoss.Microsoft.Windows 2.7.0.

Changes from 2.0.4 to 2.0.5:

- Fix version reported by "zenpacklib --version". (ZPS-1145)
- Template backups use YYYYMMDDHHMM format instead of unix timestamp.
- Fix failure to back up customized templates during upgrade from pre-2.0 ZenPacks. (ZPS-1195)
- Fix failure to back up customized templates during upgrade. (ZPS-1176)

https://github.com/zenoss/ZenPacks.zenoss.ZenPackLib/compare/2.0.4...2.0.5