### PR TITLE
Update LinuxMonitor ZenPack: 2.1.2 to 2.1.3

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -157,10 +157,8 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.LinuxMonitor",
-        "type": "zenpack",
-        "requirement": "ZenPacks.zenoss.LinuxMonitor==2.1.*",
-        "git_ref": "hotfix/2.1.3",
-        "pre": true
+        "requirement": "ZenPacks.zenoss.LinuxMonitor===2.1.3",
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.HyperV",
         "requirement": "ZenPacks.zenoss.Microsoft.HyperV===1.3.2",


### PR DESCRIPTION
Changes from 2.1.2 to 2.1.3:

- Properly account for reserved space to match df output. (ZPS-26739)

https://github.com/zenoss/ZenPacks.zenoss.LinuxMonitor/compare/2.1.2...2.1.3