### PR TITLE
Update LinuxMonitor ZenPack: hf/2.1.3 to stable

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -126,10 +126,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.LinuxMonitor",
-        "type": "zenpack",
-        "requirement": "ZenPacks.zenoss.LinuxMonitor==2.1.*",
-        "git_ref": "hotfix/2.1.3",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.HyperV",
         "type": "zenpack"


### PR DESCRIPTION
Setting LinuxMonitor back to the default of pointing to the latest
stable release. As of right now this will be LinuxMonitor 2.2.0.