### PR TITLE
Add modelindex to component_versions

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -12,6 +12,11 @@
         "version": "develop"
     },
     {
+        "name": "modelindex",
+        "type": "jenkins",
+        "version": "develop"
+    },
+    {
         "name": "pynetsnmp",
         "type": "jenkins",
         "jenkins.server": "http://jenkins.zendev.org",


### PR DESCRIPTION
First commit to get modelindex into the image.  We need it in component_versions so the Jenkins job that builds it will work.  Then we will go back and add it to the image