### PR TITLE
Add model index to image and devimg

### DIFF
--- a/devimg/create_devimg.sh
+++ b/devimg/create_devimg.sh
@@ -26,6 +26,9 @@ su - zenoss -c "ln -s ${SRCROOT}/zenoss-zep/core/src/main/sql ${ZENHOME}/share/z
 echo "Linking in zep webapp..."
 rm -rf ${ZENHOME}/webapps/zeneventserver
 su - zenoss -c "ln -s ${SRCROOT}/zenoss-zep ${ZENHOME}/webapps/zeneventserver"
+echo "Linking in modelindex..."
+rm -rf ${ZENHOME}/modelindex
+su - zenoss -c "ln -s ${SRCROOT}/modelindex ${ZENHOME}/modelindex"
 
 #TODO: do we want to do this for prodbin bin files as well?
 if [ -d ${SRCROOT}/zenoss-zep/dist/src/assembly/bin ]

--- a/product-base/install_scripts/zenoss_component_install.sh
+++ b/product-base/install_scripts/zenoss_component_install.sh
@@ -123,6 +123,17 @@ wget -q http://zenpip.zendev.org/packages/zenoss-solr-1.0dev.tgz -O /tmp/zenoss-
 tar -C "/" -xzvf /tmp/zenoss-solr.tgz
 chown -R zenoss:zenoss /var/solr
 
+# Install Modelindex
+artifactDownload "modelindex"
+su - zenoss -c "mkdir ${ZENHOME}/modelindex"
+su - zenoss -c "tar -C ${ZENHOME}/modelindex -xzvf /tmp/modelindex*"
+su - zenoss -c "pip install -r ${ZENHOME}/modelindex/requirements.txt"
+su - zenoss -c "pip install -e ${ZENHOME}/modelindex"
+# Copy the modelindex configsets into solr for bootstrapping.
+#  TODO:  when we move to external zookeeper for solr, do something else
+rm -rf /opt/solr/server/solr/configsets
+cp -R ${ZENHOME}/modelindex/zenoss/modelindex/solr/configsets /opt/solr/server/solr/
+
 # Some components have files which are read-only by zenoss, so we need to
 # open up the permissions to allow read/write for the group and read for
 # all others.  We need to make this minimal setting here to facilitate


### PR DESCRIPTION
Installs latest modelindex develop build into $ZENHOME/modelindex in the zenoss base image.
Links in modelindex source in devimg build.