### PR TITLE
Initialize model catalog

### DIFF
--- a/product-base/install_scripts/create_zenoss.sh
+++ b/product-base/install_scripts/create_zenoss.sh
@@ -37,6 +37,9 @@ pkill redis
 echo "Stopping rabbit..."
 /sbin/rabbitmqctl stop
 
+echo "Stopping solr..."
+kill $SOLR_PID
+
 sleep 10
 echo "Cleaning up mysql data..."
 rm /var/lib/mysql/ib_logfile0
@@ -45,6 +48,7 @@ rm /var/lib/mysql/ib_logfile1
 echo "Cleaning up after install..."
 find ${ZENHOME} -name \*.py[co] -delete
 rm -f ${ZENHOME}/log/\*.log
+rm -rf /opt/solr/logs/*
 /sbin/scrub.sh
 
 echo "Component Artifact Report"

--- a/product-base/install_scripts/zenoss_init.sh
+++ b/product-base/install_scripts/zenoss_init.sh
@@ -71,6 +71,9 @@ fix_etc_permissions
 echo "Run zenbuild..."
 run_zenbuild
 
+echo "Initialize model catalog..."
+init_modelcatalog
+
 echo "Add default system user..."
 ${ZENHOME}/bin/zendmd --script ${ZENHOME}/bin/addSystemUser.py
 


### PR DESCRIPTION
During zenoss initialization, we start solr.  If the code for initializing model catalog exists, we run it after zodb is initialized.