### PR TITLE
BLD-75 Bump DiscoveryMapping to 1.2.1

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -77,7 +77,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DiscoveryMapping",
-        "requirement": "ZenPacks.zenoss.DiscoveryMapping===1.2.0",
+        "requirement": "ZenPacks.zenoss.DiscoveryMapping===1.2.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DistributedCollector",


### PR DESCRIPTION
Version 1.2.1 contains a unittest fix necessary for building appliances.