### PR TITLE
BLD-111 Update several ZPs for UCS-PM

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -25,7 +25,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CalculatedPerformance",
-        "requirement": "ZenPacks.zenoss.CalculatedPerformance===2.3.2",
+        "requirement": "ZenPacks.zenoss.CalculatedPerformance===2.4.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CatalogService",
@@ -41,11 +41,11 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCS",
-        "requirement": "ZenPacks.zenoss.CiscoUCS===2.5.5",
+        "requirement": "ZenPacks.zenoss.CiscoUCS===2.6.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCSCentral",
-        "requirement": "ZenPacks.zenoss.CiscoUCSCentral===1.2.0",
+        "requirement": "ZenPacks.zenoss.CiscoUCSCentral===1.3.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ComponentGroups",
@@ -97,7 +97,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.EMC.base",
-        "requirement": "ZenPacks.zenoss.EMC.base===1.1.2",
+        "requirement": "ZenPacks.zenoss.EMC.base===1.2.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.EnterpriseCollector",
@@ -165,7 +165,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.Windows",
-        "requirement": "ZenPacks.zenoss.Microsoft.Windows===2.6.11",
+        "requirement": "ZenPacks.zenoss.Microsoft.Windows===2.7.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.MySqlMonitor",
@@ -207,7 +207,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.PythonCollector",
-        "requirement": "ZenPacks.zenoss.PythonCollector===1.8.2",
+        "requirement": "ZenPacks.zenoss.PythonCollector===1.9.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.SolarisMonitor",
@@ -231,7 +231,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.UCSCapacity",
-        "requirement": "ZenPacks.zenoss.UCSCapacity===1.2.3",
+        "requirement": "ZenPacks.zenoss.UCSCapacity===1.3.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.UCSXSkin",


### PR DESCRIPTION
- CalculatedPerformance updated to 2.4.1
- CiscoUCSCentral updated to 1.3.0
- CiscoUCS updated to 2.6.0
- EMC.base updated to 1.2.0
- Microsoft.Windows updated to 2.7.0
- NetAppMonitor updated to 3.5.0
- PythonCollector updated to 1.9.0
- UCSCapacity updated to 1.3.0
- UCSXSkin updated to 2.1.8