### PR TITLE
Use 2.1.0 release of zenoss.toolbox

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -81,6 +81,6 @@
         "URL":  "http://zenpip.zendev.org/packages/{name}-{version}-py2-none-any.whl",
         "name": "zenoss.toolbox",
         "type": "download",
-        "version": "2.0.0"
+        "version": "2.1.0"
     }
 ]


### PR DESCRIPTION
Port of #351.
Fixes ZEN-27374.