### PR TITLE
Update EMC ZenPack: 1.2.0 to hotfix/1.2.1

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -97,7 +97,9 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.EMC.base",
-        "requirement": "ZenPacks.zenoss.EMC.base===1.2.0",
+        "ref": "hotfix/1.2.1",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.EMC.base==1.2.*",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.EnterpriseCollector",


### PR DESCRIPTION
Changes from 1.2.0 to hotfix/1.2.1:

- Enable adding VNX File devices from multi-device add wizard (ZPS-1440)
- Fix "old_data_path" errors on Zenoss 5.2.3 and newer (ZPS-1392)

https://github.com/zenoss/ZenPacks.zenoss.EMC/compare/1.2.0...hotfix/1.2.1