### PR TITLE
feature ZEN-27471: use develop version of zproxy in develop builds

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -79,10 +79,11 @@
         "version": "1.3.2"
     },
     {
-        "URL":  "http://zenpip.zendev.org/packages/{name}-{version}.tar.gz",
         "name": "zproxy",
-        "type": "download",
-        "version": "1.0.1"
+        "type": "jenkins",
+        "jenkins.server": "http://platform-jenkins.zenoss.eng",
+        "jenkins.job": "Components/job/zproxy/job/develop",
+        "version": "develop"
     },
     {
         "URL":  "http://zenpip.zendev.org/packages/{name}-{version}-py2-none-any.whl",


### PR DESCRIPTION
configure Thebe builds to use develop builds of zproxy toward features around special purpose dedicated Zope instances.