### PR TITLE
Update PredictiveThreshold: 1.2.2dev to latest

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -153,10 +153,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.PredictiveThreshold",
-        "type": "zenpack",
-        "requirement": "ZenPacks.zenoss.PredictiveThreshold==1.2.*",
-        "git_ref": "hotfix/1.2.2",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.PortalIntegration",
         "type": "zenpack"


### PR DESCRIPTION
The hotfix/1.2.2 branch was released as 1.2.2. So the develop branch of
product-assembly should be restored to including the latest release of
PredictiveThreshold. That would be 1.2.2 as of the time of this commit.