### PR TITLE
Update PredictiveThreshold ZenPack: 1.2.1 to 1.2.2

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -195,7 +195,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.PredictiveThreshold",
-        "requirement": "ZenPacks.zenoss.PredictiveThreshold===1.2.1",
+        "requirement": "ZenPacks.zenoss.PredictiveThreshold===1.2.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.PortalIntegration",


### PR DESCRIPTION
Changes from 1.2.1 to 1.2.2:

- Add unit of measure to graph export (ZEN-19837)

https://github.com/zenoss/ZenPacks.zenoss.PredictiveThreshold/compare/1.2.1...1.2.2