### PR TITLE
Specify git_owner for service-migration

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -32,7 +32,8 @@
         "URL": "http://zenpip.zendev.org/packages/servicemigration-{version}-py2-none-any.whl",
         "name": "service-migration",
         "type": "download",
-        "version": "1.1.7"
+        "version": "1.1.7",
+        "git_owner": "control-center"
     },
     {
         "URL": "http://zenpip.zendev.org/packages/zenoss.extjs-{version}.tar.gz",


### PR DESCRIPTION
This is required for zendev init, and zendev restore to work with
support/5.2.x. Without this change the following errors occur.

    $ zendev restore support/5.2.x
    ZENDEV: Checking out 'support/5.2.x' for product-assembly ...
    ZENDEV: Generating list of github repos and versions ...
    ZENDEV: Checking out github repos defined by /z/ucspm/.zendev/.repos.json
    ERRO[0003] Problem running git command     cmd=git clone --progress git@github.com:zenoss/service-migration.git /z/ucspm/src/github.com/zenoss/service-migration path=. repo=github.com/zenoss/service-migration
    ERRO[0003] Problem running git command     cmd=git fetch --progress --all path=/z/ucspm/src/github.com/zenoss/service-migration repo=github.com/zenoss/service-migration
    ERRO[0003] Unable to checkout ref          err= ref=1.1.7 repo=git@github.com:zenoss/service-migration.git