### PR TITLE
Update LinuxMonitor: 2.2.0 to 2.2.2

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -159,7 +159,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.LinuxMonitor",
-        "requirement": "ZenPacks.zenoss.LinuxMonitor===2.2.0",
+        "requirement": "ZenPacks.zenoss.LinuxMonitor===2.2.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.HyperV",


### PR DESCRIPTION
Changes from 2.2.0 to 2.2.2:

- Improved OS Model parser for os_release modeler plugin. (ZPS-1177)
- Fix query service overloading during Analytics ETL of Linux devices. (ZPS-1312)
- Honor zFileSystemIgnoreTypes in zenoss.cmd.linux.df modeler plugin. (ZPS-1494)

https://github.com/zenoss/ZenPacks.zenoss.LinuxMonitor/compare/2.2.0...2.2.2