### PR TITLE
Update CiscoUCS: 2.6.0 to hotfix/2.6.1

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -41,7 +41,9 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCS",
-        "requirement": "ZenPacks.zenoss.CiscoUCS===2.6.0",
+        "requirement": "ZenPacks.zenoss.CiscoUCS==2.6.*",
+        "git_ref": "hotfix/2.6.1",
+        "pre": true,
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCSCentral",


### PR DESCRIPTION
Temporarily build from CiscoUCS hotfix/2.6.1 branch instead of a tagged
release so QA can test incoming changes for UCS-PM "Juliet".

Current changes from 2.6.0 to hotfix/2.6.1:

- Add UCS device types to multi-device add wizard. (ZPS-1421)
- Fix CIMC severity comment graph points. (ZPS-1361)
- Set zCollectorClientTimeout to 600 (ZPS-1519)

More changes may occur before the UCS-PM "Juliet" release.

https://github.com/zenoss/ZenPacks.zenoss.CiscoUCS/compare/2.6.0...hotfix/2.6.1