### PR TITLE
Update CiscoUCSCentral: 1.3.0 to hotfix/1.3.1

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -47,7 +47,9 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCSCentral",
-        "requirement": "ZenPacks.zenoss.CiscoUCSCentral===1.3.0",
+        "requirement": "ZenPacks.zenoss.CiscoUCSCentral==1.3.*",
+        "git_ref": "hotfix/1.3.1",
+        "pre": true,
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ComponentGroups",


### PR DESCRIPTION
Temporarily build from CiscoUCSCentral hotfix/1.3.1 branch instead of a
tagged release so QA can test incoming changes for UCS-PM "Juliet".

Current changes from 1.3.0 to hotfix/1.3.1:

- Add Cisco UCS Central to multi-device add wizard (ZPS-1421)
- Fix templates showing in profiles list (ZPS-668)

More changes may occur before the UCS-PM "Juliet" release.

https://github.com/zenoss/ZenPacks.zenoss.CiscoUCSCentral/compare/1.3.0...hotfix/1.3.1