### PR TITLE
CC-3557 UCSPM Version should be used for upgrade script

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -37,10 +37,10 @@ getDownloadLogs:
 	docker run --rm -v $(PWD):/mnt/export -t $(TAG) rsync -a /opt/zenoss/log/zenoss_component_artifact.log /opt/zenoss/log/zenpacks_artifact.log /mnt/export
 
 upgrade-%.txt:
-	@sed -e 's/%HBASE_VERSION%/$(HBASE_VERSION)/g; s/%OPENTSDB_VERSION%/$(OPENTSDB_VERSION)/g; s/%SHORT_VERSION%/$(SHORT_VERSION)/g; s/%VERSION%/$(VERSION)/g; s/%RELEASE_PHASE%/$(MATURITY)/g; s/%VERSION_TAG%/$(VERSION_TAG)/g;' upgrade-$*.txt.in > $@
+	@sed -e 's/%HBASE_VERSION%/$(HBASE_VERSION)/g; s/%OPENTSDB_VERSION%/$(OPENTSDB_VERSION)/g; s/%SHORT_VERSION%/$(SHORT_VERSION)/g; s/%VERSION%/$(VERSION)/g; s/%UCSPM_VERSION%/$(UCSPM_VERSION)/g; s/%RELEASE_PHASE%/$(MATURITY)/g; s/%VERSION_TAG%/$(VERSION_TAG)/g;' upgrade-$*.txt.in > $@
 
 upgrade-%.sh:
-	@sed -e 's/%SHORT_VERSION%/$(SHORT_VERSION)/g; s/%VERSION%/$(VERSION)/g;' upgrade-$*.sh.in > $@
+	@sed -e 's/%SHORT_VERSION%/$(SHORT_VERSION)/g; s/%VERSION%/$(VERSION)/g; s/%UCSPM_VERSION%/$(UCSPM_VERSION)/g;' upgrade-$*.sh.in > $@
 	@chmod +x $@
 
 run-tests:


### PR DESCRIPTION
Fix adds another line in common.mk to replace %UCSPM_VERSION% with the value for $UCSPM_VERSION
[Jira](https://jira.zenoss.com/browse/CC-3557)