### PR TITLE
Fix Jenkins deprecated warnings

### DIFF
--- a/Jenkins-begin.groovy
+++ b/Jenkins-begin.groovy
@@ -17,7 +17,7 @@ node ('build-zenoss-product') {
     currentBuild.displayName = "product build #${PRODUCT_BUILD_NUMBER}"
 
     try {
-        stage 'Checkout product-assembly repo'
+        stage ('Checkout product-assembly repo') {
             // Make sure we start in a clean directory to ensure a fresh git clone
             deleteDir()
             git branch: BRANCH, credentialsId: GIT_CREDENTIAL_ID, url: 'https://github.com/zenoss/product-assembly'
@@ -26,8 +26,9 @@ node ('build-zenoss-product') {
             sh("git rev-parse HEAD >git_sha.id")
             GIT_SHA=readFile('git_sha.id').trim()
             println("Building from git commit='${GIT_SHA}' on branch ${BRANCH} for MATURITY='${MATURITY}'")
+        }
 
-        stage 'Build product-base'
+        stage ('Build product-base') {
             if (PINNED == "true") {
                 // make sure SVCDEF_GIT_REF has is of the form x.x.x, where x is an integer
                 sh("grep '^SVCDEF_GIT_REF=[0-9]\\{1,\\}\\.[0-9]\\{1,\\}\\.[0-9]\\{1,\\}' versions.mk")
@@ -35,11 +36,13 @@ node ('build-zenoss-product') {
                 sh("./artifact_download.py zenpack_versions.json --pinned")
             }
             sh("cd product-base;MATURITY=${MATURITY} BUILD_NUMBER=${PRODUCT_BUILD_NUMBER} make clean build")
+        }
 
-        stage 'Push product-base'
+        stage ('Push product-base') {
             sh("cd product-base;MATURITY=${MATURITY} BUILD_NUMBER=${PRODUCT_BUILD_NUMBER} make push clean")
+        }
 
-        stage 'Run all product pipelines'
+        stage ('Run all product pipelines') {
             def branches = [
                 'core-pipeline': {
                     build job: 'core-pipeline', parameters: [
@@ -74,6 +77,7 @@ node ('build-zenoss-product') {
             // Set the status to success because the finally block is about to execute
             //      and we don't want the final report status to be "IN-PROGRESS"
             currentBuild.result = 'SUCCESS'
+        }
     } catch (err) {
         echo "Job failed with the following error: ${err}"
         if (err.toString().contains("completed with status ABORTED") ||

--- a/Jenkins-image.groovy
+++ b/Jenkins-image.groovy
@@ -15,7 +15,7 @@ node ('build-zenoss-product') {
     def pipelineBuildNumber = env.BUILD_NUMBER
     currentBuild.displayName = "product build #${PRODUCT_BUILD_NUMBER} (pipeline job #${pipelineBuildNumber})"
 
-    stage 'Build image'
+    stage ('Build image') {
         // Make sure we start in a clean directory to ensure a fresh git clone
         deleteDir()
         // NOTE: The 'master' branch name here is only used to clone the github repo.
@@ -43,14 +43,17 @@ node ('build-zenoss-product') {
 
         def includePattern = TARGET_PRODUCT + '/*artifact.log'
         archive includes: includePattern
+    }
 
-    stage 'Test image'
+    stage ('Test image') {
         sh("cd ${TARGET_PRODUCT};MATURITY=${MATURITY} BUILD_NUMBER=${PRODUCT_BUILD_NUMBER} make run-tests")
+    }
 
-    stage 'Push image'
+    stage ('Push image') {
         sh("cd ${TARGET_PRODUCT};MATURITY=${MATURITY} BUILD_NUMBER=${PRODUCT_BUILD_NUMBER} make push clean")
+    }
 
-    stage 'Compile service definitions and build RPM'
+    stage ('Compile service definitions and build RPM') {
         // Run the checkout in a separate directory. We have to clean it ourselves, because Jenkins doesn't (apparently)
         sh("rm -rf svcdefs/build;mkdir -p svcdefs/build/zenoss-service")
         dir('svcdefs/build/zenoss-service') {
@@ -74,8 +77,9 @@ node ('build-zenoss-product') {
             TARGET_PRODUCT=${TARGET_PRODUCT}"
         sh("cd svcdefs;make build ${makeArgs}")
         archive includes: 'svcdefs/build/zenoss-service/output/**'
+    }
 
-    stage 'Push RPM'
+    stage ('Push RPM') {
         // FIXME - if we never use the pipeline to build/publish artifacts directly to the stable or
         //         testing repos, then maybe we should remove MATURITY as an argument for this job?
         def s3Subdirectory = "/yum/zenoss/" + MATURITY + "/centos/el7/os/x86_64"
@@ -86,8 +90,9 @@ node ('build-zenoss-product') {
             [$class: 'StringParameterValue', name: 'S3_BUCKET', value: 'get.zenoss.io'],
             [$class: 'StringParameterValue', name: 'S3_SUBDIR', value: s3Subdirectory]
         ]
+    }
 
-    stage 'Build Appliances'
+    stage ('Build Appliances') {
         if (BUILD_APPLIANCES != "true") {
             echo "Skipped Build Appliances"
             return
@@ -138,4 +143,5 @@ node ('build-zenoss-product') {
         }
 
         parallel branches
+    }
 }

--- a/Jenkins-promote.groovy
+++ b/Jenkins-promote.groovy
@@ -32,7 +32,7 @@ node ('build-zenoss-product') {
     currentBuild.displayName = "promote ${TARGET_PRODUCT} from ${FROM_MATURITY} to ${TO_MATURITY}"
     def childJobLabel = TARGET_PRODUCT + " promote to " + TO_MATURITY
 
-    stage 'Promote image'
+    stage ('Promote image') {
         // Make sure we start in a clean directory to ensure a fresh git clone
         deleteDir()
         // NOTE: The 'master' branch name here is only used to clone the github repo.
@@ -68,8 +68,9 @@ node ('build-zenoss-product') {
             TO_MATURITY=${TO_MATURITY}\
             TO_RELEASEPHASE=${TO_RELEASEPHASE}"
         sh("cd svcdefs;${promoteArgs} ./image_promote.sh")
+    }
 
-    stage 'Compile service definitions and build RPM'
+    stage ('Compile service definitions and build RPM') {
         // Run the checkout in a separate directory. We have to clean it ourselves, because Jenkins doesn't (apparently)
         sh("rm -rf svcdefs/build;mkdir -p svcdefs/build/zenoss-service")
         dir('svcdefs/build/zenoss-service') {
@@ -90,8 +91,9 @@ node ('build-zenoss-product') {
             TARGET_PRODUCT=${TARGET_PRODUCT}"
         sh("cd svcdefs;make build ${makeArgs}")
         archive includes: 'svcdefs/build/zenoss-service/output/**'
+    }
 
-    stage 'Push RPM'
+    stage ('Push RPM') {
         // FIXME - if we never use the pipeline to build/publish artifacts directly to the stable or
         //         testing repos, then maybe we should remove MATURITY as an argument for this job?
         def s3Subdirectory = "/yum/zenoss/" + TO_MATURITY + "/centos/el7/os/x86_64"
@@ -101,8 +103,9 @@ node ('build-zenoss-product') {
             [$class: 'StringParameterValue', name: 'S3_BUCKET', value: 'get.zenoss.io'],
             [$class: 'StringParameterValue', name: 'S3_SUBDIR', value: s3Subdirectory]
         ]
+    }
 
-    stage 'Build Appliances'
+    stage ('Build Appliances') {
         if (BUILD_APPLIANCES != "true") {
             echo "Skipped Build Appliances"
             return
@@ -156,4 +159,5 @@ node ('build-zenoss-product') {
         }
 
         parallel branches
+    }
 }


### PR DESCRIPTION
Now that we've updated jenkins, we can correct the groovy syntax to prevent warnings like:
```
[Pipeline] stage (Build product-base)
Using the ‘stage’ step without a block argument is deprecated
Entering stage Build product-base
```