### PR TITLE
Remove incorrect argument

### DIFF
--- a/build_status.py
+++ b/build_status.py
@@ -378,7 +378,7 @@ def buildReport(templates, jobInfo, jobName):
         if not found:
             jobs = []
             if stageTemplate.childTemplate:
-                jobs = addChildJobTemplates(stageTemplate, templates, stageTemplate.childTemplate, jenkinsInfo.name)
+                jobs = addChildJobTemplates(templates, stageTemplate.childTemplate, jenkinsInfo.name)
             stageInfo = StageInfo(stageTemplate.name, None, None, jobs)
 
         stages.append(stageInfo)


### PR DESCRIPTION
Fixes this failure:
```
[begin] Running shell script
+ ./build_status.py -b develop -p 244 --job-name begin --job-status FAILURE -html buildReport.html
INFO:root:begin:product build #244 @docker-centos-7-3 - FAILURE
INFO:root:found 3 stage(s) for 'Run all product pipelines'
INFO:root:core-pipeline:product build #244 (pipeline job #223 @docker-centos-7-12) - FAILED
Traceback (most recent call last):
  File "./build_status.py", line 623, in <module>
    main(options)
  File "./build_status.py", line 589, in main
    report = buildReport(templates, beginJobInfo, "begin")
  File "./build_status.py", line 373, in buildReport
    addChildJobs(stageTemplate, templates, stage, jobs)
  File "./build_status.py", line 435, in addChildJobs
    childJobReport = buildReport(templates, jobInfo, jobName)
  File "./build_status.py", line 381, in buildReport
    jobs = addChildJobTemplates(stageTemplate, templates, stageTemplate.childTemplate, jenkinsInfo.name)
TypeError: addChildJobTemplates() takes exactly 3 arguments (4 given)
```