### PR TITLE
Backport changes from BLD-149

### DIFF
--- a/Jenkins-begin.groovy
+++ b/Jenkins-begin.groovy
@@ -14,7 +14,7 @@ node ('build-zenoss-product') {
     // define 'PRODUCT_BUILD_NUMBER' as the parameter name that will be used by all downstream
     // jobs to identify a particular execution of the build pipeline.
     PRODUCT_BUILD_NUMBER=env.BUILD_NUMBER
-    currentBuild.displayName = "product build #${PRODUCT_BUILD_NUMBER}"
+    currentBuild.displayName = "product build #${PRODUCT_BUILD_NUMBER} @${env.NODE_NAME}"
 
     try {
         stage ('Checkout product-assembly repo') {

--- a/Jenkins-begin.groovy
+++ b/Jenkins-begin.groovy
@@ -17,7 +17,7 @@ node ('build-zenoss-product') {
     currentBuild.displayName = "product build #${PRODUCT_BUILD_NUMBER}"
 
     try {
-        stage 'Checkout product-assembly repo'
+        stage ('Checkout product-assembly repo') {
             // Make sure we start in a clean directory to ensure a fresh git clone
             deleteDir()
             git branch: BRANCH, credentialsId: GIT_CREDENTIAL_ID, url: 'https://github.com/zenoss/product-assembly'
@@ -26,8 +26,9 @@ node ('build-zenoss-product') {
             sh("git rev-parse HEAD >git_sha.id")
             GIT_SHA=readFile('git_sha.id').trim()
             println("Building from git commit='${GIT_SHA}' on branch ${BRANCH} for MATURITY='${MATURITY}'")
+        }
 
-        stage 'Build product-base'
+        stage ('Build product-base') {
             if (PINNED == "true") {
                 // make sure SVCDEF_GIT_REF has is of the form x.x.x, where x is an integer
                 sh("grep '^SVCDEF_GIT_REF=[0-9]\\{1,\\}\\.[0-9]\\{1,\\}\\.[0-9]\\{1,\\}' versions.mk")
@@ -35,11 +36,13 @@ node ('build-zenoss-product') {
                 sh("./artifact_download.py zenpack_versions.json --pinned")
             }
             sh("cd product-base;MATURITY=${MATURITY} BUILD_NUMBER=${PRODUCT_BUILD_NUMBER} make clean build")
+        }
 
-        stage 'Push product-base'
+        stage ('Push product-base') {
             sh("cd product-base;MATURITY=${MATURITY} BUILD_NUMBER=${PRODUCT_BUILD_NUMBER} make push clean")
+        }
 
-        stage 'Run all product pipelines'
+        stage ('Run all product pipelines') {
             def branches = [
                 'core-pipeline': {
                     build job: 'core-pipeline', parameters: [
@@ -74,6 +77,7 @@ node ('build-zenoss-product') {
             // Set the status to success because the finally block is about to execute
             //      and we don't want the final report status to be "IN-PROGRESS"
             currentBuild.result = 'SUCCESS'
+        }
     } catch (err) {
         echo "Job failed with the following error: ${err}"
         if (err.toString().contains("completed with status ABORTED") ||

--- a/Jenkins-image.groovy
+++ b/Jenkins-image.groovy
@@ -13,7 +13,14 @@
 node ('build-zenoss-product') {
     def pipelineBuildName = env.JOB_NAME
     def pipelineBuildNumber = env.BUILD_NUMBER
-    currentBuild.displayName = "product build #${PRODUCT_BUILD_NUMBER} (pipeline job #${pipelineBuildNumber})"
+    currentBuild.displayName = "product build #${PRODUCT_BUILD_NUMBER} (pipeline job #${pipelineBuildNumber} @${env.NODE_NAME})"
+
+    def SVCDEF_GIT_REF=""
+    def ZENOSS_VERSION=""
+    def SERVICED_BRANCH=""
+    def SERVICED_MATURITY=""
+    def SERVICED_VERSION=""
+    def SERVICED_BUILD_NUMBER=""
 
     stage ('Build image') {
         // Make sure we start in a clean directory to ensure a fresh git clone
@@ -25,12 +32,12 @@ node ('build-zenoss-product') {
 
         // Get the values of various versions out of the versions.mk file for use in later stages
         def versionProps = readProperties file: 'versions.mk'
-        def SVCDEF_GIT_REF=versionProps['SVCDEF_GIT_REF']
-        def ZENOSS_VERSION=versionProps['VERSION']
-        def SERVICED_BRANCH=versionProps['SERVICED_BRANCH']
-        def SERVICED_MATURITY=versionProps['SERVICED_MATURITY']
-        def SERVICED_VERSION=versionProps['SERVICED_VERSION']
-        def SERVICED_BUILD_NUMBER=versionProps['SERVICED_BUILD_NUMBER']
+        SVCDEF_GIT_REF=versionProps['SVCDEF_GIT_REF']
+        ZENOSS_VERSION=versionProps['VERSION']
+        SERVICED_BRANCH=versionProps['SERVICED_BRANCH']
+        SERVICED_MATURITY=versionProps['SERVICED_MATURITY']
+        SERVICED_VERSION=versionProps['SERVICED_VERSION']
+        SERVICED_BUILD_NUMBER=versionProps['SERVICED_BUILD_NUMBER']
         echo "SVCDEF_GIT_REF=${SVCDEF_GIT_REF}"
         echo "ZENOSS_VERSION=${ZENOSS_VERSION}"
         echo "SERVICED_BRANCH=${SERVICED_BRANCH}"

--- a/Jenkins-image.groovy
+++ b/Jenkins-image.groovy
@@ -15,7 +15,7 @@ node ('build-zenoss-product') {
     def pipelineBuildNumber = env.BUILD_NUMBER
     currentBuild.displayName = "product build #${PRODUCT_BUILD_NUMBER} (pipeline job #${pipelineBuildNumber})"
 
-    stage 'Build image'
+    stage ('Build image') {
         // Make sure we start in a clean directory to ensure a fresh git clone
         deleteDir()
         // NOTE: The 'master' branch name here is only used to clone the github repo.
@@ -43,14 +43,17 @@ node ('build-zenoss-product') {
 
         def includePattern = TARGET_PRODUCT + '/*artifact.log'
         archive includes: includePattern
+    }
 
-    stage 'Test image'
+    stage ('Test image') {
         sh("cd ${TARGET_PRODUCT};MATURITY=${MATURITY} BUILD_NUMBER=${PRODUCT_BUILD_NUMBER} make run-tests")
+    }
 
-    stage 'Push image'
+    stage ('Push image') {
         sh("cd ${TARGET_PRODUCT};MATURITY=${MATURITY} BUILD_NUMBER=${PRODUCT_BUILD_NUMBER} make push clean")
+    }
 
-    stage 'Compile service definitions and build RPM'
+    stage ('Compile service definitions and build RPM') {
         // Run the checkout in a separate directory. We have to clean it ourselves, because Jenkins doesn't (apparently)
         sh("rm -rf svcdefs/build;mkdir -p svcdefs/build/zenoss-service")
         dir('svcdefs/build/zenoss-service') {
@@ -74,8 +77,9 @@ node ('build-zenoss-product') {
             TARGET_PRODUCT=${TARGET_PRODUCT}"
         sh("cd svcdefs;make build ${makeArgs}")
         archive includes: 'svcdefs/build/zenoss-service/output/**'
+    }
 
-    stage 'Push RPM'
+    stage ('Push RPM') {
         // FIXME - if we never use the pipeline to build/publish artifacts directly to the stable or
         //         testing repos, then maybe we should remove MATURITY as an argument for this job?
         def s3Subdirectory = "/yum/zenoss/" + MATURITY + "/centos/el7/os/x86_64"
@@ -86,8 +90,9 @@ node ('build-zenoss-product') {
             [$class: 'StringParameterValue', name: 'S3_BUCKET', value: 'get.zenoss.io'],
             [$class: 'StringParameterValue', name: 'S3_SUBDIR', value: s3Subdirectory]
         ]
+    }
 
-    stage 'Build Appliances'
+    stage ('Build Appliances') {
         if (BUILD_APPLIANCES != "true") {
             echo "Skipped Build Appliances"
             return
@@ -140,4 +145,5 @@ node ('build-zenoss-product') {
         }
 
         parallel branches
+    }
 }

--- a/Jenkins-promote.groovy
+++ b/Jenkins-promote.groovy
@@ -32,7 +32,7 @@ node ('build-zenoss-product') {
     currentBuild.displayName = "promote ${TARGET_PRODUCT} from ${FROM_MATURITY} to ${TO_MATURITY}"
     def childJobLabel = TARGET_PRODUCT + " promote to " + TO_MATURITY
 
-    stage 'Promote image'
+    stage ('Promote image') {
         // Make sure we start in a clean directory to ensure a fresh git clone
         deleteDir()
         // NOTE: The 'master' branch name here is only used to clone the github repo.
@@ -68,8 +68,9 @@ node ('build-zenoss-product') {
             TO_MATURITY=${TO_MATURITY}\
             TO_RELEASEPHASE=${TO_RELEASEPHASE}"
         sh("cd svcdefs;${promoteArgs} ./image_promote.sh")
+    }
 
-    stage 'Compile service definitions and build RPM'
+    stage ('Compile service definitions and build RPM') {
         // Run the checkout in a separate directory. We have to clean it ourselves, because Jenkins doesn't (apparently)
         sh("rm -rf svcdefs/build;mkdir -p svcdefs/build/zenoss-service")
         dir('svcdefs/build/zenoss-service') {
@@ -90,8 +91,9 @@ node ('build-zenoss-product') {
             TARGET_PRODUCT=${TARGET_PRODUCT}"
         sh("cd svcdefs;make build ${makeArgs}")
         archive includes: 'svcdefs/build/zenoss-service/output/**'
+    }
 
-    stage 'Push RPM'
+    stage ('Push RPM') {
         // FIXME - if we never use the pipeline to build/publish artifacts directly to the stable or
         //         testing repos, then maybe we should remove MATURITY as an argument for this job?
         def s3Subdirectory = "/yum/zenoss/" + TO_MATURITY + "/centos/el7/os/x86_64"
@@ -101,8 +103,9 @@ node ('build-zenoss-product') {
             [$class: 'StringParameterValue', name: 'S3_BUCKET', value: 'get.zenoss.io'],
             [$class: 'StringParameterValue', name: 'S3_SUBDIR', value: s3Subdirectory]
         ]
+    }
 
-    stage 'Build Appliances'
+    stage ('Build Appliances') {
         if (BUILD_APPLIANCES != "true") {
             echo "Skipped Build Appliances"
             return
@@ -156,4 +159,5 @@ node ('build-zenoss-product') {
         }
 
         parallel branches
+    }
 }

--- a/Jenkins-promote.groovy
+++ b/Jenkins-promote.groovy
@@ -32,6 +32,14 @@ node ('build-zenoss-product') {
     currentBuild.displayName = "promote ${TARGET_PRODUCT} from ${FROM_MATURITY} to ${TO_MATURITY}"
     def childJobLabel = TARGET_PRODUCT + " promote to " + TO_MATURITY
 
+    def SVCDEF_GIT_REF=""
+    def ZENOSS_VERSION=""
+    def ZENOSS_SHORT_VERSION=""
+    def SERVICED_BRANCH=""
+    def SERVICED_MATURITY=""
+    def SERVICED_VERSION=""
+    def SERVICED_BUILD_NUMBER=""
+
     stage ('Promote image') {
         // Make sure we start in a clean directory to ensure a fresh git clone
         deleteDir()
@@ -43,13 +51,13 @@ node ('build-zenoss-product') {
 
         // Get the values of various versions out of the versions.mk file for use in later stages
         def versionProps = readProperties file: 'versions.mk'
-        def SVCDEF_GIT_REF=versionProps['SVCDEF_GIT_REF']
-        def ZENOSS_VERSION=versionProps['VERSION']
-        def ZENOSS_SHORT_VERSION=versionProps['SHORT_VERSION']
-        def SERVICED_BRANCH=versionProps['SERVICED_BRANCH']
-        def SERVICED_MATURITY=versionProps['SERVICED_MATURITY']
-        def SERVICED_VERSION=versionProps['SERVICED_VERSION']
-        def SERVICED_BUILD_NUMBER=versionProps['SERVICED_BUILD_NUMBER']
+        SVCDEF_GIT_REF=versionProps['SVCDEF_GIT_REF']
+        ZENOSS_VERSION=versionProps['VERSION']
+        ZENOSS_SHORT_VERSION=versionProps['SHORT_VERSION']
+        SERVICED_BRANCH=versionProps['SERVICED_BRANCH']
+        SERVICED_MATURITY=versionProps['SERVICED_MATURITY']
+        SERVICED_VERSION=versionProps['SERVICED_VERSION']
+        SERVICED_BUILD_NUMBER=versionProps['SERVICED_BUILD_NUMBER']
         echo "SVCDEF_GIT_REF=${SVCDEF_GIT_REF}"
         echo "ZENOSS_VERSION=${ZENOSS_VERSION}"
         echo "ZENOSS_SHORT_VERSION=${ZENOSS_SHORT_VERSION}"

--- a/build_status.py
+++ b/build_status.py
@@ -378,7 +378,7 @@ def buildReport(templates, jobInfo, jobName):
         if not found:
             jobs = []
             if stageTemplate.childTemplate:
-                jobs = addChildJobTemplates(stageTemplate, templates, stageTemplate.childTemplate, jenkinsInfo.name)
+                jobs = addChildJobTemplates(templates, stageTemplate.childTemplate, jenkinsInfo.name)
             stageInfo = StageInfo(stageTemplate.name, None, None, jobs)
 
         stages.append(stageInfo)

--- a/jobTemplate.html
+++ b/jobTemplate.html
@@ -26,7 +26,9 @@ td.indent2 {padding-left:30px}
 td.indent3 {padding-left:45px}
 td.indent4 {padding-left:60px}
 td.indent5 {padding-left:75px}
-td.indent6 {padding-left:0px}
+td.indent6 {padding-left:90px}
+td.indent7 {padding-left:105px}
+td.indent8 {padding-left:120px}
 td.failure {color: red;}
 </style>
 </head>

--- a/jobTemplate.json
+++ b/jobTemplate.json
@@ -49,29 +49,11 @@
 			"name": "Build manifest",
 			"childTemplate": ""
 		}, {
-			"name": "Master OVA",
+			"name": "Archive manifest",
 			"childTemplate": ""
 		}, {
-			"name": "Master ISO",
-			"childTemplate": ""
-		}, {
-			"name": "Delegate ISO",
-			"childTemplate": ""
-		}, {
-			"name": "Upgrade ISO",
-			"childTemplate": ""
-		}, {
-			"name": "AMIs",
-			"childTemplate": ""
-		}, {
-			"name": "QEMU/QCOWs",
-			"childTemplate": ""
-		}, {
-			"name": "Checksum",
-			"childTemplate": ""
-		}, {
-			"name": "Archive and Upload",
-			"childTemplate": ""
+			"name": "Build master and delegate appliances",
+			"childTemplate": "do-build-appliances"
 		}, {
 			"name": "Start QA Automation",
 			"childTemplate": ""
@@ -79,9 +61,6 @@
 		"instanceTemplates": [{
 			"jobPrefix": "core appliance",
 			"ignoreStages": [
-				"Upgrade ISO",
-				"AMIs",
-				"QEMU/QCOWs",
 				"Start QA Automation"],
 			"parentJob": "core-pipeline"
 		}, {
@@ -90,21 +69,87 @@
 			"parentJob": "resmgr-pipeline"
 		}, {
 			"jobPrefix": "ucspm appliance",
-			"ignoreStages": [
-				"AMIs",
-				"QEMU/QCOWs"],
+			"ignoreStages": [],
 			"parentJob": "ucspm-pipeline"
 		}, {
 			"jobPrefix": "poc appliance",
 			"ignoreStages": [
-				"Delegate OVA",
-				"Master ISO",
-				"Delegate ISO",
-				"Upgrade ISO",
-				"AMIs",
-				"QEMU/QCOWs",
 				"Start QA Automation"],
 			"parentJob": "resmgr-pipeline"
+		}]
+	}, {
+		"name": "do-build-appliances",
+		"jobPrefixes": [],
+		"stages": [{
+			"name": "Clean and checkout",
+			"childTemplate": ""
+		}, {
+			"name": "Download manifest",
+			"childTemplate": ""
+		}, {
+			"name": "OVA",
+			"childTemplate": ""
+		}, {
+			"name": "Upload OVA",
+			"childTemplate": ""
+		}, {
+			"name": "ISO",
+			"childTemplate": ""
+		}, {
+			"name": "Upload ISO",
+			"childTemplate": ""
+		}, {
+			"name": "Upgrade ISO",
+			"childTemplate": ""
+		}, {
+			"name": "Upload Upgrade ISO",
+			"childTemplate": ""
+		}, {
+			"name": "AMIs",
+			"childTemplate": ""
+		}, {
+			"name": "Upload ami",
+			"childTemplate": ""
+		}, {
+			"name": "QEMU/QCOWs",
+			"childTemplate": ""
+		}, {
+			"name": "Upload QEMU/QCOWs",
+			"childTemplate": ""
+		}],
+		"instanceTemplates": [{
+			"jobPrefix": "core appliance",
+			"ignoreStages": [
+				"Upgrade ISO",
+				"Upload Upgrade ISO",
+				"AMIs",
+				"Upload ami",
+				"QEMU/QCOWs",
+				"Upload QEMU/QCOWs"
+			],
+			"parentJob": "appliance-build"
+		}, {
+			"jobPrefix": "poc appliance",
+			"ignoreStages": [
+				"ISO",
+				"Upload ISO",
+				"Upgrade ISO",
+				"Upload Upgrade ISO",
+				"AMIs",
+				"Upload ami",
+				"QEMU/QCOWs",
+				"Upload QEMU/QCOWs"
+			],
+			"parentJob": "appliance-build"
+		}, {
+			"jobPrefix": "ucspm appliance",
+			"ignoreStages": [
+				"AMIs",
+				"Upload ami",
+				"QEMU/QCOWs",
+				"Upload QEMU/QCOWs"
+			],
+			"parentJob": "appliance-build"
 		}]
 	}]
 }

--- a/jobTemplate.json
+++ b/jobTemplate.json
@@ -4,15 +4,19 @@
 		"jobPrefixes": [],
 		"stages": [{
 			"name": "Checkout product-assembly repo",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "Build product-base",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "Push product-base",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "Run all product pipelines",
+			"childInfoUrl": "/job/product-assembly/job/%branch%/job/%jobName%/%jobNumber%",
 			"childTemplate": "product-pipeline"
 		}],
 		"instanceTemplates": []
@@ -21,21 +25,27 @@
 		"jobPrefixes": ["core-pipeline","resmgr-pipeline","ucspm-pipeline"],
 		"stages": [{
 			"name": "Build image",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "Test image",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "Push image",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "Compile service definitions and build RPM",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "Push RPM",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "Build Appliances",
+			"childInfoUrl": "/job/product-assembly/job/%branch%/job/appliance-build/%jobNumber%",
 			"childTemplate": "appliance-build"
 		}],
 		"instanceTemplates": []
@@ -44,18 +54,23 @@
 		"jobPrefixes": [],
 		"stages": [{
 			"name": "Clean and checkout",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "Build manifest",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "Archive manifest",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "Build master and delegate appliances",
+			"childInfoUrl": "/job/product-assembly/job/%branch%/job/do-build-appliances/%jobNumber%",
 			"childTemplate": "do-build-appliances"
 		}, {
 			"name": "Start QA Automation",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}],
 		"instanceTemplates": [{
@@ -82,39 +97,51 @@
 		"jobPrefixes": [],
 		"stages": [{
 			"name": "Clean and checkout",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "Download manifest",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "OVA",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "Upload OVA",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "ISO",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "Upload ISO",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "Upgrade ISO",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "Upload Upgrade ISO",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "AMIs",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "Upload ami",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "QEMU/QCOWs",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}, {
 			"name": "Upload QEMU/QCOWs",
+			"childInfoUrl": "",
 			"childTemplate": ""
 		}],
 		"instanceTemplates": [{


### PR DESCRIPTION
Updates to groovy scripting and reporting for a combination of Jenkins server upgrades and changes to the build process to build master and delegate appliances in parallel.

Includes changes from BLD-136 and BLD-149

Also see https://github.com/zenoss/zenoss-deploy/pull/563