### PR TITLE
Fix URL for reports of branch builds

### DIFF
--- a/build_status.py
+++ b/build_status.py
@@ -262,10 +262,11 @@ def class_mapper(d):
 def loadReportTemplates(templateFile, branch):
     templates = json.loads(templateFile.read(), object_hook=class_mapper)['templates']
     log.debug("template count = %d" % len(templates))
+    branchName = branch.replace("/", "-")
     for jobTemplate in templates:
         log.debug(jobTemplate)
         for stage in jobTemplate.stages:
-            stage.childInfoUrl = stage.childInfoUrl.replace("%branch%", branch)
+            stage.childInfoUrl = stage.childInfoUrl.replace("%branch%", branchName)
             log.debug("\t%s" % stage)
         for instance in jobTemplate.instanceTemplates:
             log.debug("\t%s" % instance)


### PR DESCRIPTION
Here's an example of the broken URL which should be fixed by this PR. Note the `:` between `artifacts.zenoss.eng` and `builds`
```
All appliance artifacts are available <a href='http://artifacts.zenoss.eng:builds/5.2.x/unstable/5.2.5/453/poc'>here</a>
```

This URL is added to the job description for appliance build jobs like http://platform-jenkins.zenoss.eng/job/product-assembly/job/support-5.2.x/job/appliance-build/860/ so that people can easily jump to the corresponding folder on the artifacts server.