### PR TITLE
Update CiscoUCSCentral: hotfix/1.3.1 to 1.3.1

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -47,9 +47,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCSCentral",
-        "requirement": "ZenPacks.zenoss.CiscoUCSCentral==1.3.*",
-        "git_ref": "hotfix/1.3.1",
-        "pre": true,
+        "requirement": "ZenPacks.zenoss.CiscoUCSCentral===1.3.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ComponentGroups",


### PR DESCRIPTION
The 1.3.1 hotfix was released so we can now released the tagged version.

Changes from 1.3.0 to 1.3.1:

- Add Cisco UCS Central to multi-device add wizard. (ZPS-1421)
- Fix templates showing in service profiles list and vice versa. (ZPS-668)

https://github.com/zenoss/ZenPacks.zenoss.CiscoUCSCentral/compare/1.3.0...1.3.1