### PR TITLE
Update CiscoUCS: hotfix/2.6.1 to 2.6.1

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -41,9 +41,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCS",
-        "requirement": "ZenPacks.zenoss.CiscoUCS==2.6.*",
-        "git_ref": "hotfix/2.6.1",
-        "pre": true,
+        "requirement": "ZenPacks.zenoss.CiscoUCS===2.6.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCSCentral",


### PR DESCRIPTION
The 2.6.1 hotfix was released so we can now release the tagged version.

Changes from 2.6.0 to 2.6.1:

- Add UCS device types to multi-device add wizard. (ZPS-1421)
- The severity comment graph points were properly aligned on the CIMC graphs. (ZPS-1361)
- Increase default modeling timeout from 3 to 10 minutes. (ZPS-1519)
- Fix "ssl handshake failure" error on adding a CIMC 3.0 device. Add zCiscoUCSCIMCSSLProtocol zProperty. (ZPS-1365)
- Add a "Cisco UCS Manager - Huge Spikes on Utilization Graphs" record to the Troubleshooting section. (ZPS-1190)

https://github.com/zenoss/ZenPacks.zenoss.CiscoUCS/compare/2.6.0...2.6.1