### PR TITLE
Update EMC.base: hotfix/1.2.1 to 1.2.1

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -101,9 +101,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.EMC.base",
-        "git_ref": "hotfix/1.2.1",
-        "pre": true,
-        "requirement": "ZenPacks.zenoss.EMC.base==1.2.*",
+        "requirement": "ZenPacks.zenoss.EMC.base===1.2.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.EnterpriseCollector",


### PR DESCRIPTION
The 1.2.1 hotfix was released so we can now release the tagged version.

Changes from 1.2.0 to 1.2.1:

- Enable adding VNX File devices from multi-device add wizard (ZPS-1440)
- Fix "old_data_path" errors on Zenoss 5.2.3 and newer (ZPS-1392)

https://github.com/zenoss/ZenPacks.zenoss.EMC.base/compare/1.2.0...1.2.1