### PR TITLE
Update UCSCapacity: develop to 1.4.0

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -235,7 +235,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.UCSCapacity",
-        "pre": true,
+        "requirement": "ZenPacks.zenoss.UCSCapacity===1.4.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.UCSXSkin",


### PR DESCRIPTION
The develop branch was released as 1.4.0 so now we can release the
tagged version.

Changes from 1.3.0 to 1.4.0:

- Fix event links from Integrated Infrastructure portlet. (ZEN-14934)
- Fix capacity legend on reports to work on Zenoss 5.2. (ZPS-1500)

https://github.com/zenoss/ZenPacks.zenoss.UCSCapacity/compare/1.3.0...1.4.0