### PR TITLE
Revert ZenSQLTx: 2.6.6 to 2.6.5

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -279,7 +279,7 @@
         "requirement": "ZenPacks.zenoss.ZenPackLib===2.0.5"
     },{
         "name": "ZenPacks.zenoss.ZenSQLTx",
-        "requirement": "ZenPacks.zenoss.ZenSQLTx===2.6.6",
+        "requirement": "ZenPacks.zenoss.ZenSQLTx===2.6.5",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ZenWebTx",


### PR DESCRIPTION
A regression was introduced in 2.6.6 that prevents SQLTx datasources
from being monitored at all. ZenSQLTx 2.6.6 with this regression was
shipped with RM 5.2.3 and 5.2.4. This change will prevent it from being
shipped with 5.2.5.

Changes being reverted (2.6.6 to 2.6.5):

- Fix SQL datasource test to test from appropriate collector (ZEN-22199)

https://github.com/zenoss/ZenPacks.zenoss.ZenSQLTx/compare/2.6.6...2.6.5

Refs ZPS-1657.