### PR TITLE
Remove QCOWs from the build

### DIFF
--- a/jobTemplate.json
+++ b/jobTemplate.json
@@ -135,14 +135,6 @@
 			"name": "Upload ami",
 			"childInfoUrl": "",
 			"childTemplate": ""
-		}, {
-			"name": "QEMU/QCOWs",
-			"childInfoUrl": "",
-			"childTemplate": ""
-		}, {
-			"name": "Upload QEMU/QCOWs",
-			"childInfoUrl": "",
-			"childTemplate": ""
 		}],
 		"instanceTemplates": [{
 			"jobPrefix": "core appliance",
@@ -150,9 +142,7 @@
 				"Upgrade ISO",
 				"Upload Upgrade ISO",
 				"AMIs",
-				"Upload ami",
-				"QEMU/QCOWs",
-				"Upload QEMU/QCOWs"
+				"Upload ami"
 			],
 			"parentJob": "appliance-build"
 		}, {
@@ -163,18 +153,14 @@
 				"Upgrade ISO",
 				"Upload Upgrade ISO",
 				"AMIs",
-				"Upload ami",
-				"QEMU/QCOWs",
-				"Upload QEMU/QCOWs"
+				"Upload ami"
 			],
 			"parentJob": "appliance-build"
 		}, {
 			"jobPrefix": "ucspm appliance",
 			"ignoreStages": [
 				"AMIs",
-				"Upload ami",
-				"QEMU/QCOWs",
-				"Upload QEMU/QCOWs"
+				"Upload ami"
 			],
 			"parentJob": "appliance-build"
 		}]


### PR DESCRIPTION
Not building QCOWs will save 10-15 minutes from the total nightly build time