### PR TITLE
Use the latest query code until we're ready to release 5.2.6

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -17,10 +17,9 @@
         "version": "0.40.7"
     },
     {
-        "URL": "http://zenpip.zenoss.eng/packages/central-query-{version}-zapp.tar.gz",
         "name": "query",
-        "type": "download",
-        "version": "0.1.20"
+        "type": "jenkins",
+        "version": "develop"
     },
     {
         "URL": "http://zenpip.zenoss.eng/packages/{name}-{version}.tgz",


### PR DESCRIPTION
## Need to wait until CC and prodbin changes are in before merging 

https://jira.zenoss.com/browse/ZEN-27644

Bring in the latest query code for updated graphs.  The query repo will need to be released and this version updated when we release 5.2.6.