### PR TITLE
ZEN-27838: use develop version of zproxy until 1.0.3 is released

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -74,10 +74,11 @@
         "version": "1.4.0"
     },
     {
-        "URL": "http://zenpip.zenoss.eng/packages/zproxy-{version}.tar.gz",
         "name": "zproxy",
-        "type": "download",
-        "version": "1.0.2"
+        "type": "jenkins",
+        "jenkins.server": "http://platform-jenkins.zenoss.eng",
+        "jenkins.job": "Components/job/zproxy/job/develop",
+        "version": "develop"
     },
     {
         "URL":  "http://zenpip.zenoss.eng/packages/{name}-{version}-py2-none-any.whl",


### PR DESCRIPTION
This is in support of the 5.2.6 backport for debug-Zopes and API-Zopes