### PR TITLE
Update LinuxMonitor: hotfix/2.2.5 to 2.2.5

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -157,9 +157,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.LinuxMonitor",
-        "requirement": "ZenPacks.zenoss.LinuxMonitor==2.2.*",
-        "git_ref": "hotfix/2.2.5",
-        "pre": true,
+        "requirement": "ZenPacks.zenoss.LinuxMonitor===2.2.5",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.HyperV",


### PR DESCRIPTION
2.2.5 has been released so we can now pin the version instead of building the
hotfix branch. Noting changes from 2.2.2 to 2.2.5 because prior to switching
to building the hotfix/2.2.5 branch, we were including LinuxMonitor 2.2.2 with
Zenoss 5.2.x releases.

Changes from 2.2.2 to 2.2.5:

- Use FileSystem_NFS_Client template for all NFS mounts (including nfs4). (ZPS-1495)
- Prevent the creation of orphaned processes when an NFS mount becomes unavailable. (ZPS-1499)
- Fix "IndexError" when modeling tun interfaces. (ZPS-971)
- Add percentUsed datapoint for filesystems. Use for UI and events. (ZPS-1545)
- Escape the commandTemplate expression for disk and idisk datasources to avoid TALES errors. (ZPS-1616)
- Fix RPN errors in aliases for memory, swap, and LVM (ZPS-757)
- Fix modeler 'AttributeError: type' error when zInterfaceMapIgnoreTypes is set. (ZPS-1695)

https://github.com/zenoss/ZenPacks.zenoss.LinuxMonitor/compare/hotfix/2.2.5...2.2.5