### PR TITLE
ZEN-27335 Use opentsdb image tag 24.0.6

### DIFF
--- a/versions.mk
+++ b/versions.mk
@@ -24,9 +24,9 @@ VERSION_TAG=1
 # Currently, HDFS and OpenTSDB use the same image as HBASE
 # So these versions should always be the same.
 #
-HBASE_VERSION=24.0.5
-HDFS_VERSION=24.0.5
-OPENTSDB_VERSION=24.0.5
+HBASE_VERSION=24.0.6
+HDFS_VERSION=24.0.6
+OPENTSDB_VERSION=24.0.6
 
 
 #


### PR DESCRIPTION
This version of the opentsdb image includes a script
that collects metrics from Infrastructure opentsdb and
sends it to CC's opentsdb for self-monitoring purposes.