### PR TITLE
Change for hotfix build

### DIFF
--- a/Jenkins-begin.groovy
+++ b/Jenkins-begin.groovy
@@ -49,6 +49,7 @@ node ('build-zenoss-product') {
                         [$class: 'StringParameterValue', name: 'GIT_CREDENTIAL_ID', value: GIT_CREDENTIAL_ID],
                         [$class: 'StringParameterValue', name: 'GIT_SHA', value: GIT_SHA],
                         [$class: 'StringParameterValue', name: 'MATURITY', value: MATURITY],
+                        [$class: 'StringParameterValue', name: 'BRANCH', value: BRANCH],
                         [$class: 'StringParameterValue', name: 'PRODUCT_BUILD_NUMBER', value: PRODUCT_BUILD_NUMBER],
                         [$class: 'BooleanParameterValue', name: 'BUILD_APPLIANCES', value: BUILD_APPLIANCES.toBoolean()],
                     ]
@@ -58,6 +59,7 @@ node ('build-zenoss-product') {
                         [$class: 'StringParameterValue', name: 'GIT_CREDENTIAL_ID', value: GIT_CREDENTIAL_ID],
                         [$class: 'StringParameterValue', name: 'GIT_SHA', value: GIT_SHA],
                         [$class: 'StringParameterValue', name: 'MATURITY', value: MATURITY],
+                        [$class: 'StringParameterValue', name: 'BRANCH', value: BRANCH],
                         [$class: 'StringParameterValue', name: 'PRODUCT_BUILD_NUMBER', value: PRODUCT_BUILD_NUMBER],
                         [$class: 'BooleanParameterValue', name: 'BUILD_APPLIANCES', value: BUILD_APPLIANCES.toBoolean()],
                     ]
@@ -67,6 +69,7 @@ node ('build-zenoss-product') {
                         [$class: 'StringParameterValue', name: 'GIT_CREDENTIAL_ID', value: GIT_CREDENTIAL_ID],
                         [$class: 'StringParameterValue', name: 'GIT_SHA', value: GIT_SHA],
                         [$class: 'StringParameterValue', name: 'MATURITY', value: MATURITY],
+                        [$class: 'StringParameterValue', name: 'BRANCH', value: BRANCH],
                         [$class: 'StringParameterValue', name: 'PRODUCT_BUILD_NUMBER', value: PRODUCT_BUILD_NUMBER],
                         [$class: 'BooleanParameterValue', name: 'BUILD_APPLIANCES', value: BUILD_APPLIANCES.toBoolean()],
                     ]

--- a/Jenkins-image.groovy
+++ b/Jenkins-image.groovy
@@ -122,6 +122,7 @@ node ('build-zenoss-product') {
                     build job: 'appliance-build', parameters: [
                             [$class: 'StringParameterValue', name: 'JOB_LABEL', value: jobLabel],
                             [$class: 'StringParameterValue', name: 'TARGET_PRODUCT', value: applianceTarget],
+                            [$class: 'StringParameterValue', name: 'BRANCH', value: BRANCH],
                             [$class: 'StringParameterValue', name: 'PRODUCT_BUILD_NUMBER', value: PRODUCT_BUILD_NUMBER],
                             [$class: 'StringParameterValue', name: 'ZENOSS_MATURITY', value: MATURITY],
                             [$class: 'StringParameterValue', name: 'ZENOSS_VERSION', value: ZENOSS_VERSION],

--- a/Jenkins-promote.groovy
+++ b/Jenkins-promote.groovy
@@ -137,6 +137,7 @@ node ('build-zenoss-product') {
                     build job: 'appliance-build', parameters: [
                             [$class: 'StringParameterValue', name: 'JOB_LABEL', value: jobLabel],
                             [$class: 'StringParameterValue', name: 'TARGET_PRODUCT', value: applianceTarget],
+                            [$class: 'StringParameterValue', name: 'BRANCH', value: BRANCH],
                             [$class: 'StringParameterValue', name: 'PRODUCT_BUILD_NUMBER', value: TO_RELEASEPHASE],
                             [$class: 'StringParameterValue', name: 'ZENOSS_MATURITY', value: TO_MATURITY],
                             [$class: 'StringParameterValue', name: 'ZENOSS_VERSION', value: ZENOSS_VERSION],
@@ -155,6 +156,7 @@ node ('build-zenoss-product') {
                 build job: 'appliance-build', parameters: [
                         [$class: 'StringParameterValue', name: 'JOB_LABEL', value: jobLabel],
                         [$class: 'StringParameterValue', name: 'TARGET_PRODUCT', value: TARGET_PRODUCT],
+                        [$class: 'StringParameterValue', name: 'BRANCH', value: BRANCH],
                         [$class: 'StringParameterValue', name: 'PRODUCT_BUILD_NUMBER', value: TO_RELEASEPHASE],
                         [$class: 'StringParameterValue', name: 'ZENOSS_MATURITY', value: TO_MATURITY],
                         [$class: 'StringParameterValue', name: 'ZENOSS_VERSION', value: ZENOSS_VERSION],

--- a/versions.mk
+++ b/versions.mk
@@ -15,7 +15,7 @@
 # UCSPM_VERSION     the version of the ucspm release; e.g 2.1.0
 #
 SHORT_VERSION=5.2
-SVCDEF_GIT_REF=5.2.5
+SVCDEF_GIT_REF=hotfix/5.2.6
 VERSION=5.2.6
 UCSPM_VERSION=2.5.1
 VERSION_TAG=1


### PR DESCRIPTION
1. Use the updated service-definitions to get the right version (depends on https://github.com/zenoss/zenoss-service/pull/418 being merged first)

2. Take the value of the `BRANCH` parameter from the begin job and pass it down the `appliance-build` job so that zenoss-deploy builds appliances from the same branch named used to launch the build. 

PS. To get the later to work, I changed the Jenkins job definitions for support-5.2.x `core-pipeline`, `resmgr-pipeline` and `ucspm-pipeline` to add a new parameter named `BRANCH`
