### PR TITLE
ZEN-27524: Update/delete migrate scripts that use deleted catalogs

### DIFF
--- a/core/upgrade-core.txt.in
+++ b/core/upgrade-core.txt.in
@@ -44,6 +44,12 @@ SVC_START Zenoss.core/Infrastructure/redis
 # Wait for our services to start
 SVC_WAIT Zenoss.core/Infrastructure/mariadb Zenoss.core/Infrastructure/RabbitMQ Zenoss.core/Zenoss/Events/zeneventserver Zenoss.core/Infrastructure/redis started 1200
 
+# Add the Solr service if we don't have it, so migrations can use modelindex
+SVC_EXEC NO_COMMIT "Zenoss.core/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=AddSolrService --dont-bump
+SVC_START Zenoss.core/Infrastructure/solr
+SVC_RESTART Zenoss.core/Zenoss/Events/zeneventserver
+SVC_WAIT Zenoss.core/Infrastructure/solr Zenoss.core/Zenoss/Events/zeneventserver started 600
+
 # Run the upgrade 'run'
 SVC_RUN "Zenoss.core/Zenoss/User Interface/Zope" upgrade
 

--- a/resmgr/upgrade-impact.txt.in
+++ b/resmgr/upgrade-impact.txt.in
@@ -46,6 +46,12 @@ SVC_START Zenoss.resmgr/Infrastructure/Impact
 # Wait for our services to start
 SVC_WAIT Zenoss.resmgr/Infrastructure/mariadb-model Zenoss.resmgr/Infrastructure/mariadb-events Zenoss.resmgr/Infrastructure/RabbitMQ Zenoss.resmgr/Zenoss/Events/zeneventserver Zenoss.resmgr/Infrastructure/redis Zenoss.resmgr/Infrastructure/Impact started 1200
 
+# Add the Solr service if we don't have it, so migrations can use modelindex
+SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=AddSolrService --dont-bump
+SVC_START Zenoss.resmgr/Infrastructure/solr
+SVC_RESTART Zenoss.resmgr/Zenoss/Events/zeneventserver
+SVC_WAIT Zenoss.resmgr/Infrastructure/solr Zenoss.resmgr/Zenoss/Events/zeneventserver started 600
+
 # Run the upgrade 'run'
 SVC_RUN "Zenoss.resmgr/Zenoss/User Interface/Zope" upgrade
 

--- a/resmgr/upgrade-resmgr.txt.in
+++ b/resmgr/upgrade-resmgr.txt.in
@@ -45,6 +45,12 @@ SVC_START Zenoss.resmgr/Infrastructure/redis
 # Wait for our services to start
 SVC_WAIT Zenoss.resmgr/Infrastructure/mariadb-model Zenoss.resmgr/Infrastructure/mariadb-events Zenoss.resmgr/Infrastructure/RabbitMQ Zenoss.resmgr/Zenoss/Events/zeneventserver Zenoss.resmgr/Infrastructure/redis started 1200
 
+# Add the Solr service if we don't have it, so migrations can use modelindex
+SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=AddSolrService --dont-bump
+SVC_START Zenoss.resmgr/Infrastructure/solr
+SVC_RESTART Zenoss.resmgr/Zenoss/Events/zeneventserver
+SVC_WAIT Zenoss.resmgr/Infrastructure/solr Zenoss.resmgr/Zenoss/Events/zeneventserver started 600
+
 # Run the upgrade 'run'
 SVC_RUN "Zenoss.resmgr/Zenoss/User Interface/Zope" upgrade
 


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-27524

Needs https://github.com/zenoss/zenoss-prodbin/pull/2517 for dont-bump option.