### PR TITLE
Update AixMonitor: 2.2.2 to 2.2.3

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -5,7 +5,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.AixMonitor",
-        "requirement": "ZenPacks.zenoss.AixMonitor===2.2.2",
+        "requirement": "ZenPacks.zenoss.AixMonitor===2.2.3",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ApacheMonitor",


### PR DESCRIPTION
Changes from 2.2.2 to 2.2.3:

- Fix aliases for standard reports (ZPS-1390)

https://github.com/zenoss/ZenPacks.zenoss.AixMonitor/compare/2.2.2...2.2.3