### PR TITLE
Update DurationThreshold: 2.0.2 to 2.0.4

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -89,7 +89,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DurationThreshold",
-        "requirement": "ZenPacks.zenoss.DurationThreshold===2.0.2",
+        "requirement": "ZenPacks.zenoss.DurationThreshold===2.0.4",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DynamicView",


### PR DESCRIPTION
Changes from 2.0.2 to 2.0.4:

- Restore event.current field to be current value of datapoint. (ZPS-1223)
- Clear misconfiguration events when configuration is fixed. (ZPS-675)
- Encode self.TimePeriod in checkRaw() into an ascii string. (ZPS-1420)

https://github.com/zenoss/ZenPacks.zenoss.DurationThreshold/compare/2.0.2...2.0.4