### PR TITLE
Update HpuxMonitor: 2.0.1 to 2.0.2

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -125,7 +125,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.HpuxMonitor",
-        "requirement": "ZenPacks.zenoss.HpuxMonitor===2.0.1",
+        "requirement": "ZenPacks.zenoss.HpuxMonitor===2.0.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.HttpMonitor",


### PR DESCRIPTION
Changes from 2.0.1 to 2.0.2:

- Fix process monitoring for newer Zenoss versions. (ZPS-711)

https://github.com/zenoss/ZenPacks.zenoss.HpuxMonitor/compare/2.0.1...2.0.2