### PR TITLE
Update HyperV: 1.3.2 to 1.3.3

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -161,7 +161,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.HyperV",
-        "requirement": "ZenPacks.zenoss.Microsoft.HyperV===1.3.2",
+        "requirement": "ZenPacks.zenoss.Microsoft.HyperV===1.3.3",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.Windows",


### PR DESCRIPTION
Changes from 1.3.2 to 1.3.3:

- Fix erroneous Hyper-V VM creation events. (ZPS-841)

https://github.com/zenoss/ZenPacks.zenoss.HyperV/compare/1.3.2...1.3.3