### PR TITLE
Update Windows: 2.7.4 to 2.7.8

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -165,7 +165,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.Windows",
-        "requirement": "ZenPacks.zenoss.Microsoft.Windows===2.7.4",
+        "requirement": "ZenPacks.zenoss.Microsoft.Windows===2.7.8",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.MySqlMonitor",


### PR DESCRIPTION
Changes from 2.7.4 to 2.7.8:

- Fix Windows ZP uses a lot of RAM when it contains hundreds of components due to checking for IIS (ZPS-1576)
- Fix Microsoft Windows: zenpython memory usage increases until restart required (ZPS-1584)
- Fix traceback during modeling (ZPS-1599)
- Fix redundant publishing of service state datapoints (ZPS-1604)
- Fix HardDisks with a size of 'None' cause unhandled exceptions in modeling (ZPS-1424)
- Fix Log line for "periodic maintenance" shows in incorrect logs (ZPS-1600)
- Fix Failed model job does not result in event (ZPS-1608)
- Fix Performance tables are not created even though performance batch is successful (ZPS-1605)
- Fix Traceback modelling with WinMSSQL plugin (ZPS-1676)
- Fix Custom command needs to allow datapoints with non-zero exit codes (ZPS-1366)
- Fix Shutting down the Zenpython daemon creates unnecessary and or mis-catagorized logging connection failure events in zenpython.log (ZPS-1693)
- Fix Microsoft Windows - Cluster MSSQL server is at 100% CPU utilization (ZPS-1697)

https://github.com/zenoss/ZenPacks.zenoss.Windows/compare/2.7.4...2.7.8