### PR TITLE
Update MySqlMonitor: 3.0.7 to 3.0.9

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -169,7 +169,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.MySqlMonitor",
-        "requirement": "ZenPacks.zenoss.MySqlMonitor===3.0.7",
+        "requirement": "ZenPacks.zenoss.MySqlMonitor===3.0.9",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.NetAppMonitor",


### PR DESCRIPTION
Changes from 3.0.7 to 3.0.9:

-   Give datasource events unique eventKeys to avoid false-clearing (ZPS-500)
-   Set default timeouts for data collection DB connection (ZPS-313)
-   Update events and event class mappings to facilitate transforms (ZPS-500)

https://github.com/zenoss/ZenPacks.zenoss.MySqlMonitor/compare/3.0.7...3.0.9