### PR TITLE
Update NetScreenMonitor: 2.2.2 to 2.2.3

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -181,7 +181,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.NetScreenMonitor",
-        "requirement": "ZenPacks.zenoss.NetScreenMonitor===2.2.2",
+        "requirement": "ZenPacks.zenoss.NetScreenMonitor===2.2.3",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.NortelMonitor",


### PR DESCRIPTION
Changes from 2.2.2 to 2.2.3:

- Add monitoring and locking to VPN tunnels. (ZPS-603)

https://github.com/zenoss/ZenPacks.zenoss.NetScreenMonitor/compare/2.2.2...2.2.3