### PR TITLE
Update PropertyMonitor: 1.1.0 to 1.1.1

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -201,7 +201,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.PropertyMonitor",
-        "requirement": "ZenPacks.zenoss.PropertyMonitor===1.1.0",
+        "requirement": "ZenPacks.zenoss.PropertyMonitor===1.1.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.PythonCollector",


### PR DESCRIPTION
Changes from 1.1.0 to 1.1.1:

- Fix errors that can occur with components with certain characters in their IDs (ZPS-293)

https://github.com/zenoss/ZenPacks.zenoss.PropertyMonitor/compare/1.1.0...1.1.1