### PR TITLE
Update vSphere: 3.6.2 to 3.6.3

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -237,7 +237,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.vSphere",
-        "requirement": "ZenPacks.zenoss.vSphere===3.6.2",
+        "requirement": "ZenPacks.zenoss.vSphere===3.6.3",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.WBEM",


### PR DESCRIPTION
Changes from 3.6.2 to 3.6.3:

- Fix issue that can cause duplicated components (ZPS-1614)
- Include vSphere devices in standard device tables in analytics (ZPS-1501)

https://github.com/zenoss/ZenPacks.zenoss.vSphere/compare/3.6.2...3.6.3