### PR TITLE
Update ZenWebTx: 3.0.0 to 3.0.1

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -281,7 +281,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ZenWebTx",
-        "requirement": "ZenPacks.zenoss.ZenWebTx===3.0.0",
+        "requirement": "ZenPacks.zenoss.ZenWebTx===3.0.1",
         "type": "zenpack"
     }
 ]


### PR DESCRIPTION
Changes from 3.0.0 to 3.0.1:

- Initial password is not displayed in ZenWebTx datasource. (ZPS-1289)

https://github.com/zenoss/ZenPacks.zenoss.ZenWebTx/compare/3.0.0...3.0.1