### PR TITLE
Update LinuxMonitor: 2.2.5 to 2.2.6

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -157,7 +157,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.LinuxMonitor",
-        "requirement": "ZenPacks.zenoss.LinuxMonitor===2.2.5",
+        "requirement": "ZenPacks.zenoss.LinuxMonitor===2.2.6",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.HyperV",


### PR DESCRIPTION
Changes from 2.2.5 to 2.2.6:

- Fix issue with links between Linux and NetApp FileSystem components. (ZPS-1736)
- Prevent the creation of orphaned processes when an NFS mount becomes unavailable. (ZPS-1499)
- Document support for RHEL 7, Ubuntu 16.04 LTS, and Debian 8. (ZPS-1820)
- Fix spurious warnings in zencommand log when monitoring NFS mounted filesystems. (ZPS-1823)
- Calculate memory utilization using "MemAvailable" when possible. (ZPS-1144)
- Fix 0.0% utilization in Windows filesystem threshold event summaries. (ZPS-1844)

https://github.com/zenoss/ZenPacks.zenoss.LinuxMonitor/compare/2.2.5...2.2.6