### PR TITLE
Update all Solutions ZenPacks for Amalthea

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -5,7 +5,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.AixMonitor",
-        "requirement": "ZenPacks.zenoss.AixMonitor===2.2.2",
+        "requirement": "ZenPacks.zenoss.AixMonitor===2.2.3",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ApacheMonitor",
@@ -89,7 +89,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DurationThreshold",
-        "requirement": "ZenPacks.zenoss.DurationThreshold===2.0.2",
+        "requirement": "ZenPacks.zenoss.DurationThreshold===2.0.4",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DynamicView",
@@ -125,7 +125,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.HpuxMonitor",
-        "requirement": "ZenPacks.zenoss.HpuxMonitor===2.0.1",
+        "requirement": "ZenPacks.zenoss.HpuxMonitor===2.0.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.HttpMonitor",
@@ -157,19 +157,19 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.LinuxMonitor",
-        "requirement": "ZenPacks.zenoss.LinuxMonitor===2.2.5",
+        "requirement": "ZenPacks.zenoss.LinuxMonitor===2.2.6",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.HyperV",
-        "requirement": "ZenPacks.zenoss.Microsoft.HyperV===1.3.2",
+        "requirement": "ZenPacks.zenoss.Microsoft.HyperV===1.3.3",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.Windows",
-        "requirement": "ZenPacks.zenoss.Microsoft.Windows===2.7.4",
+        "requirement": "ZenPacks.zenoss.Microsoft.Windows===2.7.8",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.MySqlMonitor",
-        "requirement": "ZenPacks.zenoss.MySqlMonitor===3.0.7",
+        "requirement": "ZenPacks.zenoss.MySqlMonitor===3.0.9",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.NetAppMonitor",
@@ -181,7 +181,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.NetScreenMonitor",
-        "requirement": "ZenPacks.zenoss.NetScreenMonitor===2.2.2",
+        "requirement": "ZenPacks.zenoss.NetScreenMonitor===2.2.3",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.NortelMonitor",
@@ -201,11 +201,11 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.PropertyMonitor",
-        "requirement": "ZenPacks.zenoss.PropertyMonitor===1.1.0",
+        "requirement": "ZenPacks.zenoss.PropertyMonitor===1.1.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.PythonCollector",
-        "requirement": "ZenPacks.zenoss.PythonCollector===1.9.0",
+        "requirement": "ZenPacks.zenoss.PythonCollector===1.10.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.SolarisMonitor",
@@ -213,7 +213,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.StorageBase",
-        "requirement": "ZenPacks.zenoss.StorageBase===1.4.1",
+        "requirement": "ZenPacks.zenoss.StorageBase===1.4.3",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.SupportBundle",
@@ -237,7 +237,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.vSphere",
-        "requirement": "ZenPacks.zenoss.vSphere===3.6.2",
+        "requirement": "ZenPacks.zenoss.vSphere===3.6.3",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.WBEM",
@@ -281,7 +281,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ZenWebTx",
-        "requirement": "ZenPacks.zenoss.ZenWebTx===3.0.0",
+        "requirement": "ZenPacks.zenoss.ZenWebTx===3.0.1",
         "type": "zenpack"
     }
 ]


### PR DESCRIPTION
Refs ZEN-28131.

---

**Version Changes**

- AixMonitor 2.2.3 (was 2.2.2)
- DurationThreshold 2.0.4 (was 2.0.4)
- HpuxMonitor 2.0.2 (was 2.0.1)
- LinuxMonitor 2.2.6 (was 2.2.5)
- Microsoft.HyperV 1.3.3 (was 1.3.2)
- Microsoft.Windows 2.7.8 (was 2.7.4)
- MySqlMonitor 3.0.9 (was 3.0.7)
- NetScreenMonitor 2.2.3 (was 2.2.2)
- PropertyMonitor 1.1.1 (was 1.1.0)
- PythonCollector 1.10.1 (was 1.9.0)
- StorageBase 1.4.3 (was 1.4.1)
- vSphere 3.6.3 (was 3.6.2)
- ZenWebTx 3.0.1 (was 3.0.0)

---

AixMonitor 2.2.2 -> 2.2.3

- Fix aliases for standard reports (ZPS-1390)

https://github.com/zenoss/ZenPacks.zenoss.AixMonitor/compare/2.2.2...2.2.3

---

DurationThreshold 2.0.2 -> 2.0.4

- Restore event.current field to be current value of datapoint. (ZPS-1223)
- Clear misconfiguration events when configuration is fixed. (ZPS-675)
- Encode self.TimePeriod in checkRaw() into an ascii string. (ZPS-1420)

https://github.com/zenoss/ZenPacks.zenoss.DurationThreshold/compare/2.0.2...2.0.4

---

HpuxMonitor 2.0.1 -> 2.0.2

- Fix process monitoring for newer Zenoss versions. (ZPS-711)

https://github.com/zenoss/ZenPacks.zenoss.HpuxMonitor/compare/2.0.1...2.0.2

---

LinuxMonitor 2.2.5 -> 2.2.6

- Fix issue with links between Linux and NetApp FileSystem components. (ZPS-1736)
- Prevent the creation of orphaned processes when an NFS mount becomes unavailable. (ZPS-1499)
- Document support for RHEL 7, Ubuntu 16.04 LTS, and Debian 8. (ZPS-1820)
- Fix spurious warnings in zencommand log when monitoring NFS mounted filesystems. (ZPS-1823)
- Calculate memory utilization using "MemAvailable" when possible. (ZPS-1144)
- Fix 0.0% utilization in Windows filesystem threshold event summaries. (ZPS-1844)

https://github.com/zenoss/ZenPacks.zenoss.LinuxMonitor/compare/2.2.5...2.2.6

---

Microsoft.HyperV 1.3.2 -> 1.3.3

- Fix erroneous Hyper-V VM creation events. (ZPS-841)

https://github.com/zenoss/ZenPacks.zenoss.HyperV/compare/1.3.2...1.3.3

---

Microsoft.Windows 2.7.4 -> 2.7.8

- Fix Windows ZP uses a lot of RAM when it contains hundreds of components due to checking for IIS (ZPS-1576)
- Fix Microsoft Windows: zenpython memory usage increases until restart required (ZPS-1584)
- Fix traceback during modeling (ZPS-1599)
- Fix redundant publishing of service state datapoints (ZPS-1604)
- Fix HardDisks with a size of 'None' cause unhandled exceptions in modeling (ZPS-1424)
- Fix Log line for "periodic maintenance" shows in incorrect logs (ZPS-1600)
- Fix Failed model job does not result in event (ZPS-1608)
- Fix Performance tables are not created even though performance batch is successful (ZPS-1605)
- Fix Traceback modelling with WinMSSQL plugin (ZPS-1676)
- Fix Custom command needs to allow datapoints with non-zero exit codes (ZPS-1366)
- Fix Shutting down the Zenpython daemon creates unnecessary and or mis-catagorized logging connection failure events in zenpython.log (ZPS-1693)
- Fix Microsoft Windows - Cluster MSSQL server is at 100% CPU utilization (ZPS-1697)

https://github.com/zenoss/ZenPacks.zenoss.Windows/compare/2.7.4...2.7.8

---

MySqlMonitor 3.0.7 -> 3.0.9

-   Give datasource events unique eventKeys to avoid false-clearing (ZPS-500)
-   Set default timeouts for data collection DB connection (ZPS-313)
-   Update events and event class mappings to facilitate transforms (ZPS-500)

https://github.com/zenoss/ZenPacks.zenoss.MySqlMonitor/compare/3.0.7...3.0.9

---

NetScreenMonitor 2.2.2 -> 2.2.3

- Add monitoring and locking to VPN tunnels. (ZPS-603)

https://github.com/zenoss/ZenPacks.zenoss.NetScreenMonitor/compare/2.2.2...2.2.3

---

PropertyMonitor 1.1.0 -> 1.1.1

- Fix errors that can occur with components with certain characters in their IDs (ZPS-293)

https://github.com/zenoss/ZenPacks.zenoss.PropertyMonitor/compare/1.1.0...1.1.1

---

PythonCollector 1.9.0 -> 1.10.1

- Add "runningtimeout" option to zenpython. (ZPS-1675)
- Timeout datasources that stay running for triple their cycletime. (ZPS-1675)
- Add "timedOutTasks" metric to zenpython. (ZPS-1675)
- Fix RunningTimeoutError occurring instead of proper error. (ZPS-1755)

https://github.com/zenoss/ZenPacks.zenoss.PythonCollector/compare/1.9.0...1.10.1

---

StorageBase 1.4.1 -> 1.4.3

- Fix incorrect DynamicView relations for ConvergedNetworkAdapter components. (ZPS-1162)
- Fix issue which caused to missing data on analytics server. (ZPS-1673)

https://github.com/zenoss/ZenPacks.zenoss.StorageBase/compare/1.4.1...1.4.3

---

vSphere 3.6.2 -> 3.6.3

- Fix issue that can cause duplicated components (ZPS-1614)
- Include vSphere devices in standard device tables in analytics (ZPS-1501)

https://github.com/zenoss/ZenPacks.zenoss.vSphere/compare/3.6.2...3.6.3

---

ZenWebTx 3.0.0 -> 3.0.1

- Initial password is not displayed in ZenWebTx datasource. (ZPS-1289)

https://github.com/zenoss/ZenPacks.zenoss.ZenWebTx/compare/3.0.0...3.0.1