### PR TITLE
Update WebLogicMonitor: 2.2.3 to 2.3.0

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -245,7 +245,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.WebLogicMonitor",
-        "requirement": "ZenPacks.zenoss.WebLogicMonitor===2.2.3",
+        "requirement": "ZenPacks.zenoss.WebLogicMonitor===2.3.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.WebsphereMonitor",


### PR DESCRIPTION
Changes from 2.2.3 to 2.3.0:

- Added JDBC monitoring template
- Updated documentation for newer versions of WebLogic Server

https://github.com/zenoss/ZenPacks.zenoss.WebLogicMonitor/compare/2.2.3...2.3.0