### PR TITLE
Pull dev build of service-migration from platform-jenkins

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -33,10 +33,8 @@
     },
     {
         "name": "service-migration",
-        "git_owner": "control-center",
         "type": "jenkins",
-        "jenkins.server": "http://jenkins.zenoss.eng",
-        "jenkins.job": "service-migration-develop",
+        "jenkins.job": "ControlCenter/job/service-migration/job/develop",
         "version": "develop"
     },
     {


### PR DESCRIPTION
I moved all service-migration builds from `jenkins.zenoss.eng` to `platform-jenkins.zenoss.eng`.
The new develop build is here - http://platform-jenkins.zenoss.eng/job/ControlCenter/job/service-migration/job/develop/

Note that Thebe will use 1.1.10-dev of service-migration, while Amalthea is using the released version of 1.1.9