### PR TITLE
Specify git info for service-migration

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -33,6 +33,7 @@
     },
     {
         "name": "service-migration",
+        "git_owner": "control-center",
         "type": "jenkins",
         "jenkins.job": "ControlCenter/job/service-migration/job/develop",
         "version": "develop"


### PR DESCRIPTION
Fixes problems with zendev like:
```
$ zendev restore develop
ZENDEV: Checking out 'develop' for product-assembly ...
ZENDEV: Generating list of github repos and versions ...
ZENDEV: Checking out github repos defined by /Users/glennjones/src/metis/.zendev/.repos.json
 0 / ? [------------------------------------------------------------------------------------------------------------------=]ERRO[0000] Problem running git command                   cmd=git clone --progress git@github.com:zenoss/service-migration.git /Users/glennjones/src/metis/src/github.com/zenoss/service-migration path=. repo=github.com/zenoss/service-migration
ERRO[0000] Problem running git command                   cmd=git fetch --progress --all path=/Users/glennjones/src/metis/src/github.com/zenoss/service-migration repo=github.com/zenoss/service-migration
ERRO[0000] Unable to checkout ref                        err= ref=develop repo=git@github.com:zenoss/service-migration.git
 0 / ? [---------------------------------------------------------------------------------------------------------------=] 3s
```