### PR TITLE
Use most recent release of CiscoUCSCentral

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -45,8 +45,8 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCSCentral",
-        "type": "zenpack",
-        "pre": true
+        "requirement": "ZenPacks.zenoss.CiscoUCSCentral===1.3.1",
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ComponentGroups",
         "requirement": "ZenPacks.zenoss.ComponentGroups===1.4.0",


### PR DESCRIPTION
This ZP is not shipped with ZSD, but needs to be pinned to execute the standard 5.3.0 release process