### PR TITLE
Bump zproxy to 1.0.4

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -80,7 +80,7 @@
         "URL":  "http://zenpip.zenoss.eng/packages/{name}-{version}.tar.gz",
         "name": "zproxy",
         "type": "download",
-        "version": "1.0.3"
+        "version": "1.0.4"
     },
     {
         "name": "zenoss.toolbox",


### PR DESCRIPTION
In order to back out a fix for Thebe which is not ready for Amalthea.