### PR TITLE
ZEN-28183: use develop for query service

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -17,10 +17,11 @@
         "version": "0.40.7"
     },
     {
-        "URL": "http://zenpip.zenoss.eng/packages/central-query-{version}-zapp.tar.gz",
+        "jenkins.server": "http://platform-jenkins.zenoss.eng",
+        "jenkins.job": "Components/job/query/job/develop",
         "name": "query",
-        "type": "download",
-        "version": "0.1.23"
+        "type": "jenkins",
+        "version": "develop"
     },
     {
         "URL": "http://zenpip.zenoss.eng/packages/{name}-{version}.tgz",


### PR DESCRIPTION
Change central query to develop to pick up changes from ZEN-28163 for ZEN-28183 for 5.3.1.