### PR TITLE
Run reindex at end of upgrade, then re-run migrations that require model catalog

### DIFF
--- a/core/upgrade-core.txt.in
+++ b/core/upgrade-core.txt.in
@@ -50,14 +50,17 @@ SVC_START Zenoss.core/Infrastructure/solr
 SVC_RESTART Zenoss.core/Zenoss/Events/zeneventserver
 SVC_WAIT Zenoss.core/Infrastructure/solr Zenoss.core/Zenoss/Events/zeneventserver started 600
 
-# Remove this before upgrade
+# Run migration to remove product class instance relationships
 SVC_EXEC NO_COMMIT "Zenoss.core/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=RemoveProductClassInstancesRelationship --dont-bump
+
+# Run the upgrade 'run'
+SVC_RUN "Zenoss.core/Zenoss/User Interface/Zope" upgrade
 
 # Do a model catalog hard reindex. This is only needed when upgrading to 6.X from 5.X
 SVC_EXEC NO_COMMIT "Zenoss.core/Zenoss/User Interface/Zope" /opt/zenoss/bin/zencatalog run --createcatalog --forceindex
 
-# Run the upgrade 'run'
-SVC_RUN "Zenoss.core/Zenoss/User Interface/Zope" upgrade
+# Re-run the migration to Remove Empty Product Class Relationships, since it uses the model catalog. This is only needed when upgrading to 6.X from 5.X
+SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=RemoveEmptyProductClassRelationships --dont-bump
 
 # Uncomment this to restart the entire application afterwards
 # SVC_RESTART Zenoss.core auto

--- a/core/upgrade-core.txt.in
+++ b/core/upgrade-core.txt.in
@@ -60,7 +60,7 @@ SVC_RUN "Zenoss.core/Zenoss/User Interface/Zope" upgrade
 SVC_EXEC NO_COMMIT "Zenoss.core/Zenoss/User Interface/Zope" /opt/zenoss/bin/zencatalog run --createcatalog --forceindex
 
 # Re-run the migration to Remove Empty Product Class Relationships, since it uses the model catalog. This is only needed when upgrading to 6.X from 5.X
-SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=RemoveEmptyProductClassRelationships --dont-bump
+SVC_EXEC NO_COMMIT "Zenoss.core/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=RemoveEmptyProductClassRelationships --dont-bump
 
 # Uncomment this to restart the entire application afterwards
 # SVC_RESTART Zenoss.core auto

--- a/resmgr/upgrade-impact.txt.in
+++ b/resmgr/upgrade-impact.txt.in
@@ -58,11 +58,14 @@ SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" /opt/zenoss/bin/ze
 # Run script to completely remove Catalog Service ZenPack
 SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" su - zenoss -c "/opt/zenoss/bin/remove_CatalogServiceZenPack.sh"
 
+# Run the upgrade 'run'
+SVC_RUN "Zenoss.resmgr/Zenoss/User Interface/Zope" upgrade
+
 # Do a model catalog hard reindex. This is only needed when upgrading to 6.X from 5.X
 SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" /opt/zenoss/bin/zencatalog run --createcatalog --forceindex
 
-# Run the upgrade 'run'
-SVC_RUN "Zenoss.resmgr/Zenoss/User Interface/Zope" upgrade
+# Re-run the migration to Remove Empty Product Class Relationships, since it uses the model catalog. This is only needed when upgrading to 6.X from 5.X
+SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=RemoveEmptyProductClassRelationships --dont-bump
 
 # Uncomment this to restart the entire application afterwards
 # SVC_RESTART Zenoss.resmgr auto

--- a/resmgr/upgrade-resmgr.txt.in
+++ b/resmgr/upgrade-resmgr.txt.in
@@ -57,11 +57,14 @@ SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" /opt/zenoss/bin/ze
 # Run script to completely remove Catalog Service ZenPack
 SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" su - zenoss -c "/opt/zenoss/bin/remove_CatalogServiceZenPack.sh"
 
+# Run the upgrade 'run'
+SVC_RUN "Zenoss.resmgr/Zenoss/User Interface/Zope" upgrade
+
 # Do a model catalog hard reindex. This is only needed when upgrading to 6.X from 5.X
 SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" /opt/zenoss/bin/zencatalog run --createcatalog --forceindex
 
-# Run the upgrade 'run'
-SVC_RUN "Zenoss.resmgr/Zenoss/User Interface/Zope" upgrade
+# Re-run the migration to Remove Empty Product Class Relationships, since it uses the model catalog. This is only needed when upgrading to 6.X from 5.X
+SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=RemoveEmptyProductClassRelationships --dont-bump
 
 # Uncomment this to restart the entire application afterwards
 # SVC_RESTART Zenoss.resmgr auto

--- a/ucspm/upgrade-ucspm.txt.in
+++ b/ucspm/upgrade-ucspm.txt.in
@@ -45,11 +45,26 @@ SVC_START ucspm/Infrastructure/redis
 # Wait for our services to start
 SVC_WAIT ucspm/Infrastructure/mariadb-model ucspm/Infrastructure/mariadb-events ucspm/Infrastructure/RabbitMQ ucspm/Zenoss/Events/zeneventserver ucspm/Infrastructure/redis started 1800
 
+# Run migration to add solr first
+SVC_EXEC NO_COMMIT "ucspm/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=AddSolrService --dont-bump
+SVC_START ucspm/Infrastructure/solr
+SVC_RESTART ucspm/Zenoss/Events/zeneventserver
+SVC_WAIT ucspm/Infrastructure/solr Zenoss.core/Zenoss/Events/zeneventserver started 600
+
+# Run migration to remove product class instance relationships
+SVC_EXEC NO_COMMIT "ucspm/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=RemoveProductClassInstancesRelationship --dont-bump
+
+# Run script to completely remove Catalog Service ZenPack
+SVC_EXEC NO_COMMIT "ucspm/Zenoss/User Interface/Zope" su - zenoss -c "/opt/zenoss/bin/remove_CatalogServiceZenPack.sh"
+
 # Run the upgrade 'run'
 SVC_RUN "ucspm/Zenoss/User Interface/Zope" upgrade
 
-# Uninstall the now-unnecessary CatalogService ZenPack
-SVC_RUN "Zenoss.resmgr/Zenoss/User Interface/Zope" zenpack-manager uninstall ZenPacks.zenoss.CatalogService
+# Do a model catalog hard reindex. This is only needed when upgrading to 6.X from 5.X
+SVC_EXEC NO_COMMIT "ucspm/Zenoss/User Interface/Zope" /opt/zenoss/bin/zencatalog run --createcatalog --forceindex
+
+# Re-run the migration to Remove Empty Product Class Relationships, since it uses the model catalog. This is only needed when upgrading to 6.X from 5.X
+SVC_EXEC NO_COMMIT "ucspm/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=RemoveEmptyProductClassRelationships --dont-bump
 
 # Uncomment this to restart the entire application afterwards
 # SVC_RESTART ucspm auto


### PR DESCRIPTION
Fixes ZEN-28515 and ZEN-28514
