### PR TITLE
Use hbase-image 24.0.8

### DIFF
--- a/versions.mk
+++ b/versions.mk
@@ -24,9 +24,9 @@ VERSION_TAG=1
 # Currently, HDFS and OpenTSDB use the same image as HBASE
 # So these versions should always be the same.
 #
-HBASE_VERSION=24.0.7
-HDFS_VERSION=24.0.7
-OPENTSDB_VERSION=24.0.7
+HBASE_VERSION=24.0.8
+HDFS_VERSION=24.0.8
+OPENTSDB_VERSION=24.0.8
 
 
 #


### PR DESCRIPTION
Update hbase-image (and opentsdb, etc.) to 24.0.8 for ZEN-28346