### PR TITLE
Add missing zenpack versions

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -14,6 +14,10 @@
         "type": "zenpack",
         "pre": true
     },{
+        "name": "ZenPacks.zenoss.AWS",
+        "type": "zenpack",
+        "pre": true
+    },{
         "name": "ZenPacks.zenoss.BigIpMonitor",
         "type": "zenpack"
     },{
@@ -23,9 +27,18 @@
         "name": "ZenPacks.zenoss.CalculatedPerformance",
         "type": "zenpack",
         "pre": true
+
+    },{
+        "name": "ZenPacks.zenoss.Ceph",
+        "type": "zenpack",
+        "pre": true
     },{
         "name": "ZenPacks.zenoss.CheckPointMonitor",
         "type": "zenpack"
+    },{
+        "name": "ZenPacks.zenoss.CiscoAPIC",
+        "type": "zenpack",
+        "pre": true
     },{
         "name": "ZenPacks.zenoss.CiscoMonitor",
         "type": "zenpack"
@@ -48,8 +61,20 @@
         "type": "zenpack",
         "pre": true
     },{
+        "name": "ZenPacks.zenoss.DatabaseMonitor",
+        "type": "zenpack",
+        "pre": true
+    },{
+        "name": "ZenPacks.zenoss.DB2",
+        "type": "zenpack",
+        "pre": true
+    },{
         "name": "ZenPacks.zenoss.DellMonitor",
         "type": "zenpack"
+    },{
+        "name": "ZenPacks.zenoss.Dell.PowerEdge",
+        "type": "zenpack",
+        "pre": true
     },{
         "name": "ZenPacks.zenoss.DeviceSearch",
         "type": "zenpack",
@@ -71,6 +96,10 @@
     },{
         "name": "ZenPacks.zenoss.DnsMonitor",
         "type": "zenpack"
+    },{
+        "name": "ZenPacks.zenoss.Docker",
+        "type": "zenpack",
+        "pre": true
     },{
         "name": "ZenPacks.zenoss.DurationThreshold",
         "type": "zenpack"
@@ -95,8 +124,16 @@
         "name": "ZenPacks.zenoss.EnterpriseSkin",
         "type": "zenpack"
     },{
+        "name": "ZenPacks.zenoss.Microsoft.Exchange",
+        "type": "zenpack",
+        "pre": true
+    },{
         "name": "ZenPacks.zenoss.FtpMonitor",
         "type": "zenpack"
+    },{
+        "name": "ZenPacks.zenoss.HP.Proliant",
+        "type": "zenpack",
+        "pre": true
     },{
         "name": "ZenPacks.zenoss.HPMonitor",
         "type": "zenpack"
@@ -107,6 +144,10 @@
         "name": "ZenPacks.zenoss.HttpMonitor",
         "type": "zenpack"
     },{
+        "name": "ZenPacks.zenoss.IBM.Power",
+        "type": "zenpack",
+        "pre": true
+    },{
         "name": "ZenPacks.zenoss.InstalledTemplatesReport",
         "type": "zenpack"
     },{
@@ -115,6 +156,10 @@
     },{
         "name": "ZenPacks.zenoss.JuniperMonitor",
         "type": "zenpack"
+    },{
+        "name": "ZenPacks.zenoss.Layer2",
+        "type": "zenpack",
+        "pre": true
     },{
         "name": "ZenPacks.zenoss.LDAPAuthenticator",
         "type": "zenpack",
@@ -129,8 +174,24 @@
         "name": "ZenPacks.zenoss.LinuxMonitor",
         "type": "zenpack"
     },{
+        "name": "ZenPacks.zenoss.Memcached",
+        "type": "zenpack",
+        "pre": true
+    },{
+        "name": "ZenPacks.zenoss.Microsoft.Azure",
+        "type": "zenpack",
+        "pre": true
+    },{
+        "name": "ZenPacks.zenoss.Microsoft.Lync",
+        "type": "zenpack",
+        "pre": true
+    },{
         "name": "ZenPacks.zenoss.Microsoft.HyperV",
         "type": "zenpack"
+    },{
+        "name": "ZenPacks.zenoss.Microsoft.MSMQ",
+        "type": "zenpack",
+        "pre": true
     },{
         "name": "ZenPacks.zenoss.Microsoft.Windows",
         "type": "zenpack"
@@ -150,8 +211,28 @@
         "name": "ZenPacks.zenoss.NortelMonitor",
         "type": "zenpack"
     },{
+        "name": "ZenPacks.zenoss.NSX",
+        "type": "zenpack",
+        "pre": true
+    },{
         "name": "ZenPacks.zenoss.NtpMonitor",
         "type": "zenpack"
+    },{
+        "name": "ZenPacks.zenoss.OpenStack",
+        "type": "zenpack",
+        "pre": true
+    },{
+        "name": "ZenPacks.zenoss.OpenStackInfrastructure",
+        "type": "zenpack",
+        "pre": true
+    },{
+        "name": "ZenPacks.zenoss.OpenvSwitch",
+        "type": "zenpack",
+        "pre": true
+    },{
+        "name": "ZenPacks.zenoss.PostgreSQL",
+        "type": "zenpack",
+        "pre": true
     },{
         "name": "ZenPacks.zenoss.PredictiveThreshold",
         "type": "zenpack"
@@ -165,6 +246,10 @@
     },{
         "name": "ZenPacks.zenoss.PythonCollector",
         "type": "zenpack"
+    },{
+        "name": "ZenPacks.zenoss.RabbitMQ",
+        "type": "zenpack",
+        "pre": true
     },{
         "name": "ZenPacks.zenoss.RMMonitor",
         "type": "zenpack",
@@ -199,11 +284,19 @@
         "name": "ZenPacks.zenoss.WBEM",
         "type": "zenpack"
     },{
+        "name": "ZenPacks.zenoss.WSMAN",
+        "type": "zenpack",
+        "pre": true
+    },{
         "name": "ZenPacks.zenoss.WebLogicMonitor",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.WebsphereMonitor",
         "type": "zenpack"
+    },{
+        "name": "ZenPacks.zenoss.XenServer",
+        "type": "zenpack",
+        "pre": true
     },{
         "name": "ZenPacks.zenoss.ZenDeviceACL",
         "type": "zenpack",

--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -15,8 +15,7 @@
         "pre": true
     },{
         "name": "ZenPacks.zenoss.AWS",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.BigIpMonitor",
         "type": "zenpack"
@@ -30,15 +29,13 @@
 
     },{
         "name": "ZenPacks.zenoss.Ceph",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CheckPointMonitor",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoAPIC",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoMonitor",
         "type": "zenpack"
@@ -62,19 +59,16 @@
         "pre": true
     },{
         "name": "ZenPacks.zenoss.DatabaseMonitor",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DB2",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DellMonitor",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Dell.PowerEdge",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DeviceSearch",
         "type": "zenpack",
@@ -98,8 +92,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Docker",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DurationThreshold",
         "type": "zenpack"
@@ -125,15 +118,13 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.Exchange",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.FtpMonitor",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.HP.Proliant",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.HPMonitor",
         "type": "zenpack"
@@ -145,8 +136,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.IBM.Power",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.InstalledTemplatesReport",
         "type": "zenpack"
@@ -158,8 +148,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Layer2",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.LDAPAuthenticator",
         "type": "zenpack",
@@ -175,23 +164,19 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Memcached",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.Azure",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.Lync",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.HyperV",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.MSMQ",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.Windows",
         "type": "zenpack"
@@ -212,27 +197,22 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.NSX",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.NtpMonitor",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.OpenStack",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.OpenStackInfrastructure",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.OpenvSwitch",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.PostgreSQL",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.PredictiveThreshold",
         "type": "zenpack"
@@ -248,8 +228,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.RabbitMQ",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.RMMonitor",
         "type": "zenpack",
@@ -285,8 +264,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.WSMAN",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.WebLogicMonitor",
         "type": "zenpack"
@@ -295,8 +273,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.XenServer",
-        "type": "zenpack",
-        "pre": true
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ZenDeviceACL",
         "type": "zenpack",


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-28739
I added new zenpacks to the manifest, but failed to add them to zenpack_version.  This adds them as develop versions, to be pinned on release.