### PR TITLE
Remove AWS zenpack to get artifact built

### DIFF
--- a/resmgr/zenpacks.json
+++ b/resmgr/zenpacks.json
@@ -3,7 +3,6 @@
         "ZenPacks.zenoss.ZenPackLib",
         "ZenPacks.zenoss.ApacheMonitor",
         "ZenPacks.zenoss.PythonCollector",
-        "ZenPacks.zenoss.AWS",
         "ZenPacks.zenoss.CalculatedPerformance",
         "ZenPacks.zenoss.Docker",
         "ZenPacks.zenoss.DurationThreshold",


### PR DESCRIPTION
Remove AWS zenpack to get a QA artifact built