### PR TITLE
Remove duplicate BigIpMonitor entry

### DIFF
--- a/resmgr/zenpacks.json
+++ b/resmgr/zenpacks.json
@@ -37,7 +37,6 @@
         "ZenPacks.zenoss.ZenSQLTx",
         "ZenPacks.zenoss.ZenWebTx",
         "ZenPacks.zenoss.NetAppMonitor",
-        "ZenPacks.zenoss.BigIpMonitor",
         "ZenPacks.zenoss.CiscoMonitor",
         "ZenPacks.zenoss.PropertyMonitor",
         "ZenPacks.zenoss.vSphere",


### PR DESCRIPTION
The BigIpMonitor zenpack is in both installed and packaged zenpacks.  According to the planning list, this should not be installed by default - so removing that entry.