### PR TITLE
Add the AWS zenpack back into the manifest

### DIFF
--- a/resmgr/zenpacks.json
+++ b/resmgr/zenpacks.json
@@ -3,6 +3,7 @@
         "ZenPacks.zenoss.ZenPackLib",
         "ZenPacks.zenoss.ApacheMonitor",
         "ZenPacks.zenoss.PythonCollector",
+        "ZenPacks.zenoss.AWS",
         "ZenPacks.zenoss.CalculatedPerformance",
         "ZenPacks.zenoss.Docker",
         "ZenPacks.zenoss.DurationThreshold",


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-28777
Now that the unit tests are passing, we need to add the AWS zenpack back into the manifest.