### PR TITLE
Revert "Add the AWS zenpack back into the manifest"

### DIFF
--- a/resmgr/zenpacks.json
+++ b/resmgr/zenpacks.json
@@ -3,7 +3,6 @@
         "ZenPacks.zenoss.ZenPackLib",
         "ZenPacks.zenoss.ApacheMonitor",
         "ZenPacks.zenoss.PythonCollector",
-        "ZenPacks.zenoss.AWS",
         "ZenPacks.zenoss.CalculatedPerformance",
         "ZenPacks.zenoss.Docker",
         "ZenPacks.zenoss.DurationThreshold",


### PR DESCRIPTION
Reverts zenoss/product-assembly#545

Test-modules with import problems:
  ZenPacks.zenoss.AWS.tests.test_dsplugins
