### PR TITLE
AWS zenpack is failing unit tests; will be added back once fixed

### DIFF
--- a/resmgr/zphistory.json
+++ b/resmgr/zphistory.json
@@ -1,5 +1,4 @@
 {
-  "ZenPacks.zenoss.AWS": "6.0.0",
   "ZenPacks.zenoss.AdvancedSearch": "5.0.0",
   "ZenPacks.zenoss.AixMonitor": "5.0.0",
   "ZenPacks.zenoss.ApacheMonitor": "5.0.0",


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-28816

The AWS zenpack is failing unit tests, so was removed from the manifest to prevent build failures.  We didn't remove it from the zphistory.json file, however, causing upgrades to behave as if this zenpack had been intentionally removed from the manifest.

The zenpack will be added again once unit tests are sorted out.