### PR TITLE
Initialize mysqld log file in the image

### DIFF
--- a/product-base/install_scripts/create_zenoss.sh
+++ b/product-base/install_scripts/create_zenoss.sh
@@ -7,6 +7,8 @@
 set -e
 set -x
 
+# ZEN-28791: Set mysqld.log initial permissions
+fix_mysqld_log
 
 start_requirements
 

--- a/product-base/install_scripts/install_lib.sh
+++ b/product-base/install_scripts/install_lib.sh
@@ -274,6 +274,14 @@ fix_etc_permissions()
     chmod 750 /etc/sudoers.d
 }
 
+# Setup /var/log/mysqld.log and give permissions to mysqld to write to it.
+fix_mysqld_log()
+{
+    echo "Initializing /var/log/mysqld.log and setting default permissions."
+    touch /var/log/mysqld.log
+    chown mysql:mysql /var/log/mysqld.log
+}
+
 DESIRED_OWNERSHIP=${DESIRED_OWNERSHIP:-"zenoss:zenoss"}
 
 function die { echo "ERROR: ${*}" >&2; exit 1; }


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-28791
The mysqld_safe wrapper previously chowned /var/log/mysqld.log, but that was removed to prevent a possible security flaw (https://mariadb.com/kb/en/mariadb-10029-release-notes/).  The file must now needs to be created and chown'd to mysql manually.  See https://jira.mariadb.org/browse/MDEV-11841 for more information.