### PR TITLE
Add the updated AWS zenpack back into the manifest

### DIFF
--- a/resmgr/zenpacks.json
+++ b/resmgr/zenpacks.json
@@ -3,6 +3,7 @@
         "ZenPacks.zenoss.ZenPackLib",
         "ZenPacks.zenoss.ApacheMonitor",
         "ZenPacks.zenoss.PythonCollector",
+        "ZenPacks.zenoss.AWS",
         "ZenPacks.zenoss.CalculatedPerformance",
         "ZenPacks.zenoss.Docker",
         "ZenPacks.zenoss.DurationThreshold",

--- a/resmgr/zphistory.json
+++ b/resmgr/zphistory.json
@@ -1,4 +1,5 @@
 {
+  "ZenPacks.zenoss.AWS": "6.0.0",
   "ZenPacks.zenoss.AdvancedSearch": "5.0.0",
   "ZenPacks.zenoss.AixMonitor": "5.0.0",
   "ZenPacks.zenoss.ApacheMonitor": "5.0.0",

--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -15,6 +15,7 @@
         "pre": true
     },{
         "name": "ZenPacks.zenoss.AWS",
+        "requirement": "ZenPacks.zenoss.AWS===3.0.3",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.BigIpMonitor",


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-28777
AWS 3.0.3 will be included in the Thebe manifest.

Passing test run at: http://platform-jenkins.zenoss.eng/job/TestBuilds/job/rp-develop-begin-pipeline/9/console