### PR TITLE
Update CiscoUCS and Windows ZenPack versions.

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -49,7 +49,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCS",
-        "requirement": "ZenPacks.zenoss.CiscoUCS===2.6.1",
+        "requirement": "ZenPacks.zenoss.CiscoUCS===2.6.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCSCentral",
@@ -217,7 +217,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Microsoft.Windows",
-        "requirement": "ZenPacks.zenoss.Microsoft.Windows===2.8.0",
+        "requirement": "ZenPacks.zenoss.Microsoft.Windows===2.8.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.MySqlMonitor",


### PR DESCRIPTION
Include ZenPacks.zenoss.CiscoUCS v2.6.2 and ZenPacks.zenoss.Microsoft.Windows v2.8.1 in the build.

Fixes ZEN-28888.