### PR TITLE
Use 2.1.6 zenoss-protocols

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -57,7 +57,7 @@
         "URL": "http://zenpip.zenoss.eng/packages/zenoss.protocols-{version}-py2-none-any.whl",
         "name": "zenoss-protocols",
         "type": "download",
-        "version": "2.1.5"
+        "version": "2.1.6"
     },
     {
         "URL": "http://zenpip.zenoss.eng/packages/zep-dist-{version}.tar.gz",


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-28918

The port from develop to use the updated zenoss-protocols.  Fixes an issue where a rabbit queue could have been created with different create arguments, causing the listener to fail.