### PR TITLE
Pull the support/6.0.x branch of prodbin

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -48,10 +48,10 @@
         "version": "4.1.3"
     },
     {
-        "URL": "http://zenpip.zenoss.eng/packages/prodbin-{version}-master-6.0.x.tar.gz",
         "name": "zenoss-prodbin",
-        "type": "download",
-        "version": "6.0.0"
+        "type": "jenkins",
+        "jenkins.job": "Components/job/zenoss-prodbin/job/support-6.0.x",
+        "version": "support/6.0.x"
     },
     {
         "URL": "http://zenpip.zenoss.eng/packages/zenoss.protocols-{version}-py2-none-any.whl",


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-28918
Pull the support/6.0.x version of prodbin