### PR TITLE
fixes ZEN-29056: Exception blocking some 5x -> 6.0.0 upgrades. This c…

### DIFF
--- a/resmgr/upgrade-impact.txt.in
+++ b/resmgr/upgrade-impact.txt.in
@@ -42,9 +42,10 @@ SVC_START Zenoss.resmgr/Infrastructure/RabbitMQ
 SVC_START Zenoss.resmgr/Zenoss/Events/zeneventserver
 SVC_START Zenoss.resmgr/Infrastructure/redis
 SVC_START Zenoss.resmgr/Infrastructure/Impact
+SVC_START Zenoss.resmgr/Infrastructure/memcached
 
 # Wait for our services to start
-SVC_WAIT Zenoss.resmgr/Infrastructure/mariadb-model Zenoss.resmgr/Infrastructure/mariadb-events Zenoss.resmgr/Infrastructure/RabbitMQ Zenoss.resmgr/Zenoss/Events/zeneventserver Zenoss.resmgr/Infrastructure/redis Zenoss.resmgr/Infrastructure/Impact started 1200
+SVC_WAIT Zenoss.resmgr/Infrastructure/mariadb-model Zenoss.resmgr/Infrastructure/mariadb-events Zenoss.resmgr/Infrastructure/RabbitMQ Zenoss.resmgr/Zenoss/Events/zeneventserver Zenoss.resmgr/Infrastructure/redis Zenoss.resmgr/Infrastructure/memcached started 1200
 
 # Run migration to add solr first
 SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=AddSolrService --dont-bump

--- a/resmgr/upgrade-resmgr.txt.in
+++ b/resmgr/upgrade-resmgr.txt.in
@@ -41,9 +41,10 @@ SVC_START Zenoss.resmgr/Infrastructure/mariadb-events
 SVC_START Zenoss.resmgr/Infrastructure/RabbitMQ
 SVC_START Zenoss.resmgr/Zenoss/Events/zeneventserver
 SVC_START Zenoss.resmgr/Infrastructure/redis
+SVC_START Zenoss.resmgr/Infrastructure/memcached
 
 # Wait for our services to start
-SVC_WAIT Zenoss.resmgr/Infrastructure/mariadb-model Zenoss.resmgr/Infrastructure/mariadb-events Zenoss.resmgr/Infrastructure/RabbitMQ Zenoss.resmgr/Zenoss/Events/zeneventserver Zenoss.resmgr/Infrastructure/redis started 1200
+SVC_WAIT Zenoss.resmgr/Infrastructure/mariadb-model Zenoss.resmgr/Infrastructure/mariadb-events Zenoss.resmgr/Infrastructure/RabbitMQ Zenoss.resmgr/Zenoss/Events/zeneventserver Zenoss.resmgr/Infrastructure/redis Zenoss.resmgr/Infrastructure/memcached started 1200
 
 # Run migration to add solr first
 SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=AddSolrService --dont-bump


### PR DESCRIPTION
…hange starts the memcached service before starting the upgrade process

Cherry-picked from https://github.com/zenoss/product-assembly/pull/578
https://jira.zenoss.com/browse/ZEN-29087

Start memcached before performing the upgrade.