### PR TITLE
Fixed earlier commit. Wait for Impact also

### DIFF
--- a/resmgr/upgrade-impact.txt.in
+++ b/resmgr/upgrade-impact.txt.in
@@ -45,7 +45,7 @@ SVC_START Zenoss.resmgr/Infrastructure/Impact
 SVC_START Zenoss.resmgr/Infrastructure/memcached
 
 # Wait for our services to start
-SVC_WAIT Zenoss.resmgr/Infrastructure/mariadb-model Zenoss.resmgr/Infrastructure/mariadb-events Zenoss.resmgr/Infrastructure/RabbitMQ Zenoss.resmgr/Zenoss/Events/zeneventserver Zenoss.resmgr/Infrastructure/redis Zenoss.resmgr/Infrastructure/memcached started 1200
+SVC_WAIT Zenoss.resmgr/Infrastructure/mariadb-model Zenoss.resmgr/Infrastructure/mariadb-events Zenoss.resmgr/Infrastructure/RabbitMQ Zenoss.resmgr/Zenoss/Events/zeneventserver Zenoss.resmgr/Infrastructure/redis Zenoss.resmgr/Infrastructure/Impact Zenoss.resmgr/Infrastructure/memcached started 1200
 
 # Run migration to add solr first
 SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=AddSolrService --dont-bump


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-29087
Cherry-picked from https://github.com/zenoss/product-assembly/pull/583
Fixes the last commit that mistakenly removed the wait for Impact while adding a wait for memcached