### PR TITLE
Use new zenoss-protocols

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -57,7 +57,7 @@
         "URL": "http://zenpip.zenoss.eng/packages/zenoss.protocols-{version}-py2-none-any.whl",
         "name": "zenoss-protocols",
         "type": "download",
-        "version": "2.1.6"
+        "version": "2.1.7"
     },
     {
         "URL": "http://zenpip.zenoss.eng/packages/zep-dist-{version}.tar.gz",


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-29074
Use new protocols version to fix the eventlet queue creation path.