### PR TITLE
Revert "ZEN-28754 Add new Router to the API to query model catalog bypassing …"

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -11,9 +11,10 @@
         "version": "1.1.4"
     },
     {
+        "URL": "http://zenpip.zenoss.eng/packages/{name}-{version}.tar.gz",
         "name": "modelindex",
-        "type": "jenkins",
-        "version": "develop"
+        "type": "download",
+        "version": "1.0.0"
     },
     {
         "URL": "http://zenpip.zenoss.eng/packages/{name}-{version}-py2-none-any.whl",


### PR DESCRIPTION
Reverts zenoss/product-assembly#585

revert as it should go simultaneously with another fix https://github.com/zenoss/zenoss-prodbin/pull/2827 to prodbin, however  tests for it are failing and I can't commit. Revert until I have fixed unittests for zenoss-prodbin/pull/2827