### PR TITLE
Update HP.Proliant: 3.3.0 to hotfix/3.3.1

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -145,7 +145,9 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.HP.Proliant",
-        "requirement": "ZenPacks.zenoss.HP.Proliant===3.3.0",
+        "requirement": "ZenPacks.zenoss.HP.Proliant==3.3.*",
+        "pre": true,
+        "git_ref": "hotfix/3.3.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.HpuxMonitor",


### PR DESCRIPTION
Temporarily using the unreleased hotfix/3.3.1 branch for HP Proliant to
fix a unit test that was broken by the fix for ZEN-28507.

https://github.com/zenoss/ZenPacks.zenoss.HP.Proliant/compare/3.3.0...hotfix/3.3.1