### PR TITLE
Update LinuxMonitor: 2.2.7dev to 2.2.7

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -191,10 +191,8 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.LinuxMonitor",
-        "requirement": "ZenPacks.zenoss.LinuxMonitor==2.2.*",
-        "type": "zenpack",
-        "git_ref": "hotfix/2.2.7",
-        "pre": "true"
+        "requirement": "ZenPacks.zenoss.LinuxMonitor===2.2.7",
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Memcached",
         "requirement": "ZenPacks.zenoss.Memcached===1.0.0",


### PR DESCRIPTION
LinuxMonitor 2.2.7 has been released. Pinning it for develop.

Changes from 2.2.6 to 2.2.7:

- Allow for restricted dmesg access in Debian 9 and SUSE 12. (ZPS-1933, ZPS-550)

https://github.com/zenoss/ZenPacks.zenoss.LinuxMonitor/compare/2.2.6...2.2.7