### PR TITLE
Update HP.Proliant: 3.3.1dev to 3.3.1

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -145,9 +145,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.HP.Proliant",
-        "requirement": "ZenPacks.zenoss.HP.Proliant==3.3.*",
-        "pre": true,
-        "git_ref": "hotfix/3.3.1",
+        "requirement": "ZenPacks.zenoss.HP.Proliant===3.3.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.HpuxMonitor",


### PR DESCRIPTION
HP.Proliant 3.3.1 has been released. Pinning it for develop.

Changes from 3.3.0 to 3.3.1:

- Updated unit tests for build platform compatability (ZPS-29150, ZEN-28507)

https://github.com/zenoss/ZenPacks.zenoss.HP.Proliant/compare/3.3.0...3.3.1