### PR TITLE
ZEN-29315: Upgrading from 6.0.1 to 6.1.0 is re-running 200.0.0 level …

### DIFF
--- a/core/upgrade-core.sh.in
+++ b/core/upgrade-core.sh.in
@@ -7,9 +7,12 @@
 ###############################################################################
 set -e
 export SERVICE_TENANT_ID="`serviced service list core --format='{{.ID}}'`"
+export UPGRADE_REINDEX
+export REMOVE_EMPTY_PRODUCT_CLASS_RELATIONSHIPS
 serviced snapshot untag $SERVICE_TENANT_ID preupgrade-core-%VERSION%
 
 FROM_VERSION=$(serviced service list core --format='{{.Version}}')
+TO_VERSION=%VERSION%
 
 if [ -z "$FROM_VERSION" ];
 then
@@ -33,6 +36,14 @@ fi
 FROM_VERSION_SHORT=$(cut -d'.' -f1,2 <<< $FROM_VERSION)
 sed -i 's/REPLACE/'"$FROM_VERSION_SHORT:$FROM_VERSION"'/g' /root/%SHORT_VERSION%.x/current_version.txt
 serviced script run /root/%SHORT_VERSION%.x/current_version.txt --service Zenoss.core
+
+if [ $(echo "${FROM_VERSION}" | cut -c1) -eq 5 ] && [ $(echo "${TO_VERSION}" | cut -c1) -eq 6 ];
+then
+    UPGRADE_REINDEX='SVC_EXEC NO_COMMIT "Zenoss.core/Zenoss/User Interface/Zope" su - zenoss -c "/opt/zenoss/bin/upgrade_reindex.sh Zenoss.core"'
+    REMOVE_EMPTY_PRODUCT_CLASS_RELATIONSHIPS='SVC_EXEC NO_COMMIT "Zenoss.core/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=RemoveEmptyProductClassRelationships --dont-bump'
+fi
+
+sed -i "s@%UPGRADE_REINDEX%@${UPGRADE_REINDEX}@g; s@%REMOVE_EMPTY_PRODUCT_CLASS_RELATIONSHIPS%@${REMOVE_EMPTY_PRODUCT_CLASS_RELATIONSHIPS}@g;" /root/%SHORT_VERSION%.x/upgrade-core.txt
 
 serviced script run /root/%SHORT_VERSION%.x/upgrade-core.txt --service Zenoss.core
 /opt/serviced/bin/serviced-set-version Zenoss.core %VERSION%

--- a/core/upgrade-core.txt.in
+++ b/core/upgrade-core.txt.in
@@ -57,10 +57,10 @@ SVC_EXEC NO_COMMIT "Zenoss.core/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenm
 SVC_RUN "Zenoss.core/Zenoss/User Interface/Zope" upgrade
 
 # Do a model catalog hard reindex. This is only needed when upgrading to 6.X from 5.X
-SVC_EXEC NO_COMMIT "Zenoss.core/Zenoss/User Interface/Zope" su - zenoss -c "/opt/zenoss/bin/upgrade_reindex.sh Zenoss.core"
+%UPGRADE_REINDEX%
 
 # Re-run the migration to Remove Empty Product Class Relationships, since it uses the model catalog. This is only needed when upgrading to 6.X from 5.X
-SVC_EXEC NO_COMMIT "Zenoss.core/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=RemoveEmptyProductClassRelationships --dont-bump
+%REMOVE_EMPTY_PRODUCT_CLASS_RELATIONSHIPS%
 
 # Uncomment this to restart the entire application afterwards
 # SVC_RESTART Zenoss.core auto

--- a/resmgr/upgrade-impact.txt.in
+++ b/resmgr/upgrade-impact.txt.in
@@ -63,10 +63,10 @@ SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" su - zenoss -c "/o
 SVC_RUN "Zenoss.resmgr/Zenoss/User Interface/Zope" upgrade
 
 # Do a model catalog hard reindex. This is only needed when upgrading to 6.X from 5.X
-SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" su - zenoss -c "/opt/zenoss/bin/upgrade_reindex.sh Zenoss.resmgr"
+%UPGRADE_REINDEX%
 
 # Re-run the migration to Remove Empty Product Class Relationships, since it uses the model catalog. This is only needed when upgrading to 6.X from 5.X
-SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=RemoveEmptyProductClassRelationships --dont-bump
+%REMOVE_EMPTY_PRODUCT_CLASS_RELATIONSHIPS%
 
 # Uncomment this to restart the entire application afterwards
 # SVC_RESTART Zenoss.resmgr auto

--- a/resmgr/upgrade-resmgr.sh.in
+++ b/resmgr/upgrade-resmgr.sh.in
@@ -7,9 +7,12 @@
 ###############################################################################
 set -e
 export SERVICE_TENANT_ID="`serviced service list resmgr --format='{{.ID}}'`"
+export UPGRADE_REINDEX
+export REMOVE_EMPTY_PRODUCT_CLASS_RELATIONSHIPS
 serviced snapshot untag $SERVICE_TENANT_ID preupgrade-resmgr-%VERSION%
 
 FROM_VERSION=$(serviced service list resmgr --format='{{.Version}}')
+TO_VERSION=%VERSION%
 
 if [ -z "$FROM_VERSION" ];
 then
@@ -33,6 +36,15 @@ fi
 FROM_VERSION_SHORT=$(cut -d'.' -f1,2 <<< $FROM_VERSION)
 sed -i 's/REPLACE/'"$FROM_VERSION_SHORT:$FROM_VERSION"'/g' /root/%SHORT_VERSION%.x/current_version.txt
 serviced script run /root/%SHORT_VERSION%.x/current_version.txt --service Zenoss.resmgr
+
+if [ $(echo "${FROM_VERSION}" | cut -c1) -eq 5 ] && [ $(echo "${TO_VERSION}" | cut -c1) -eq 6 ];
+then
+    UPGRADE_REINDEX='SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" su - zenoss -c "/opt/zenoss/bin/upgrade_reindex.sh Zenoss.resmgr"'
+    REMOVE_EMPTY_PRODUCT_CLASS_RELATIONSHIPS='SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=RemoveEmptyProductClassRelationships --dont-bump'
+fi
+
+sed -i "s@%UPGRADE_REINDEX%@${UPGRADE_REINDEX}@g; s@%REMOVE_EMPTY_PRODUCT_CLASS_RELATIONSHIPS%@${REMOVE_EMPTY_PRODUCT_CLASS_RELATIONSHIPS}@g;" /root/%SHORT_VERSION%.x/upgrade-resmgr.txt
+sed -i "s@%UPGRADE_REINDEX%@${UPGRADE_REINDEX}@g; s@%REMOVE_EMPTY_PRODUCT_CLASS_RELATIONSHIPS%@${REMOVE_EMPTY_PRODUCT_CLASS_RELATIONSHIPS}@g;" /root/%SHORT_VERSION%.x/upgrade-impact.txt
 
 if [ $(serviced service status --show-fields Name  Zenoss.resmgr/Infrastructure/Impact | grep Impact) ]; then
     serviced script run /root/%SHORT_VERSION%.x/upgrade-impact.txt --service Zenoss.resmgr

--- a/resmgr/upgrade-resmgr.txt.in
+++ b/resmgr/upgrade-resmgr.txt.in
@@ -62,10 +62,10 @@ SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" su - zenoss -c "/o
 SVC_RUN "Zenoss.resmgr/Zenoss/User Interface/Zope" upgrade
 
 # Do a model catalog hard reindex. This is only needed when upgrading to 6.X from 5.X
-SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" su - zenoss -c "/opt/zenoss/bin/upgrade_reindex.sh Zenoss.resmgr"
+%UPGRADE_REINDEX%
 
 # Re-run the migration to Remove Empty Product Class Relationships, since it uses the model catalog. This is only needed when upgrading to 6.X from 5.X
-SVC_EXEC NO_COMMIT "Zenoss.resmgr/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=RemoveEmptyProductClassRelationships --dont-bump
+%REMOVE_EMPTY_PRODUCT_CLASS_RELATIONSHIPS%
 
 # Uncomment this to restart the entire application afterwards
 # SVC_RESTART Zenoss.resmgr auto

--- a/ucspm/upgrade-ucspm.sh.in
+++ b/ucspm/upgrade-ucspm.sh.in
@@ -7,9 +7,12 @@
 ###############################################################################
 set -e
 export UCSPM_TENANT_ID="`serviced service list ucspm --format='{{.ID}}'`"
+export UPGRADE_REINDEX
+export REMOVE_EMPTY_PRODUCT_CLASS_RELATIONSHIPS
 serviced snapshot untag $UCSPM_TENANT_ID preupgrade-ucspm-%VERSION%
 
 FROM_VERSION=$(serviced service list ucspm --format='{{.Version}}')
+TO_VERSION=%VERSION%
 
 if [ -z "$FROM_VERSION" ];
 then
@@ -33,6 +36,14 @@ fi
 FROM_VERSION_SHORT=$(cut -d'.' -f1,2 <<< $FROM_VERSION)
 sed -i 's/REPLACE/'"$FROM_VERSION_SHORT:$FROM_VERSION"'/g' /root/%SHORT_VERSION%.x/current_version.txt
 serviced script run /root/%SHORT_VERSION%.x/current_version.txt --service ucspm
+
+if [ $(echo "${FROM_VERSION}" | cut -c1) -eq 5 ] && [ $(echo "${TO_VERSION}" | cut -c1) -eq 6 ];
+then
+    UPGRADE_REINDEX='SVC_EXEC NO_COMMIT "ucspm/Zenoss/User Interface/Zope" su - zenoss -c "/opt/zenoss/bin/upgrade_reindex.sh ucspm"'
+    REMOVE_EMPTY_PRODUCT_CLASS_RELATIONSHIPS='SVC_EXEC NO_COMMIT "ucspm/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=RemoveEmptyProductClassRelationships --dont-bump'
+fi
+
+sed -i "s@%UPGRADE_REINDEX%@${UPGRADE_REINDEX}@g; s@%REMOVE_EMPTY_PRODUCT_CLASS_RELATIONSHIPS%@${REMOVE_EMPTY_PRODUCT_CLASS_RELATIONSHIPS}@g;" /root/%SHORT_VERSION%.x/upgrade-ucspm.txt
 
 serviced script run /root/%SHORT_VERSION%.x/upgrade-ucspm.txt --service ucspm
 /opt/serviced/bin/serviced-set-version UCSPM %UCSPM_VERSION%

--- a/ucspm/upgrade-ucspm.txt.in
+++ b/ucspm/upgrade-ucspm.txt.in
@@ -61,10 +61,10 @@ SVC_EXEC NO_COMMIT "ucspm/Zenoss/User Interface/Zope" su - zenoss -c "/opt/zenos
 SVC_RUN "ucspm/Zenoss/User Interface/Zope" upgrade
 
 # Do a model catalog hard reindex. This is only needed when upgrading to 6.X from 5.X
-SVC_EXEC NO_COMMIT "ucspm/Zenoss/User Interface/Zope" su - zenoss -c "/opt/zenoss/bin/upgrade_reindex.sh ucspm"
+%UPGRADE_REINDEX%
 
 # Re-run the migration to Remove Empty Product Class Relationships, since it uses the model catalog. This is only needed when upgrading to 6.X from 5.X
-SVC_EXEC NO_COMMIT "ucspm/Zenoss/User Interface/Zope" /opt/zenoss/bin/zenmigrate --step=RemoveEmptyProductClassRelationships --dont-bump
+%REMOVE_EMPTY_PRODUCT_CLASS_RELATIONSHIPS%
 
 # Uncomment this to restart the entire application afterwards
 # SVC_RESTART ucspm auto


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-29315

I use `@` in `sed` because its slashes conflict with slashes in variables. `sed` can use any character as delimiter.