### PR TITLE
Use zenoss-centos-base 1.2.13

### DIFF
--- a/devimg/docker_run_dumpzodb.sh
+++ b/devimg/docker_run_dumpzodb.sh
@@ -58,23 +58,13 @@ set -x
 # be sure the container gets cleaned up on exit
 #
 PWD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-echo "docker run \
-	--rm \
-	--cidfile ${CONTAINER_ID_FILE} \
-	-v ${ZENDEV_ROOT}/zenhome:/opt/zenoss \
-	-v ${ZENDEV_ROOT}/var_zenoss:/var/zenoss \
-	-v ${SRCROOT}:/mnt/src \
-	-v ${PWD}:/mnt/devimg \
-        -v ${HOME}/.m2:/home/zenoss/.m2 \
-        -t ${TAG} \
-	/mnt/devimg/dump_zodb.sh ${ZENWIPE_ARGS}
-"
+
 docker run \
 	--rm \
 	--cidfile ${CONTAINER_ID_FILE} \
 	-v ${ZENDEV_ROOT}/zenhome:/opt/zenoss \
 	-v ${ZENDEV_ROOT}/var_zenoss:/var/zenoss \
-	-v ${SRCROOT}:/mnt/src \
+	-v ${SRCROOT}/github.com/zenoss:/mnt/src \
 	-v ${PWD}:/mnt/devimg \
         -v ${HOME}/.m2:/home/zenoss/.m2 \
         -t ${TAG} \

--- a/product-base/makefile
+++ b/product-base/makefile
@@ -2,7 +2,7 @@ include ../versions.mk
 IMAGENAME  = product-base
 MATURITY ?= DEV
 BUILD_NUMBER  ?= DEV
-FROM_IMAGE ?= zenoss-centos-base:1.2.12
+FROM_IMAGE ?= zenoss-centos-base:1.2.13
 
 TAG ?= zenoss/$(IMAGENAME):$(VERSION)_$(BUILD_NUMBER)_$(MATURITY)
 


### PR DESCRIPTION
* Use most recent version of zenoss-centos-base
* Properly mount source when performing a "dumpdb"