### PR TITLE
Update ZenPackLib: 2.0.8 to 2.0.9

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -363,10 +363,8 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ZenPackLib",
-        "requirement": "ZenPacks.zenoss.ZenPackLib==2.0.*",
-        "type": "zenpack",
-        "git_ref": "hotfix/2.0.9",
-        "pre": "true"
+        "requirement": "ZenPacks.zenoss.ZenPackLib===2.0.9",
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ZenSQLTx",
         "requirement": "ZenPacks.zenoss.ZenSQLTx===2.7.1",


### PR DESCRIPTION
Changes from 2.0.8 to 2.0.9:

- Fix incorrect removal of organizers such as /Status event class (ZPS-2660)

https://github.com/zenoss/ZenPacks.zenoss.ZenPackLib/compare/2.0.8...2.0.9