### PR TITLE
Use zenoss-centos-base 1.2.14

### DIFF
--- a/product-base/makefile
+++ b/product-base/makefile
@@ -2,7 +2,7 @@ include ../versions.mk
 IMAGENAME  = product-base
 MATURITY ?= DEV
 BUILD_NUMBER  ?= DEV
-FROM_IMAGE ?= zenoss-centos-base:1.2.13
+FROM_IMAGE ?= zenoss-centos-base:1.2.14
 
 TAG ?= zenoss/$(IMAGENAME):$(VERSION)_$(BUILD_NUMBER)_$(MATURITY)
 


### PR DESCRIPTION
This version of zenoss-centos-base uses the latest version of zenoss-pydeps, which updates the python cryptography package to version 1.9.