### PR TITLE
Add zing-connector to supplementary.json

### DIFF
--- a/supplementary.json
+++ b/supplementary.json
@@ -17,6 +17,10 @@
     },
     {
         "ref": "develop",
+        "repo": "git@github.com:zenoss/zing-connector.git"
+    },
+    {
+        "ref": "develop",
         "repo": "git@github.com:control-center/serviced.git"
     },
     {


### PR DESCRIPTION
So `zendev restore develop` will checkout zing-connector along with everything else.