### PR TITLE
Pin AWS, Dashboard, and DynamicView for 6.1.1

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -17,10 +17,8 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.AWS",
-        "requirement": "ZenPacks.zenoss.AWS==4.0.*",
-        "git_ref": "hotfix/4.0.1",
-        "type": "zenpack",
-        "pre": true
+        "requirement": "ZenPacks.zenoss.AWS===4.0.1",
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.BigIpMonitor",
         "requirement": "ZenPacks.zenoss.BigIpMonitor===2.7.1",
@@ -67,8 +65,8 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Dashboard",
-        "type": "zenpack",
-        "pre": "true"
+        "requirement": "ZenPacks.zenoss.Dashboard===1.2.8",
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DatabaseMonitor",
         "requirement": "ZenPacks.zenoss.DatabaseMonitor===3.0.12",
@@ -115,8 +113,8 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DynamicView",
-        "type": "zenpack",
-        "pre": true
+        "requirement": "ZenPacks.zenoss.DynamicView===1.5.0",
+        "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.EMC.base",
         "requirement": "ZenPacks.zenoss.EMC.base===2.0.0",


### PR DESCRIPTION
AWS 4.0.1 is new version.
Dashboard and DynamicView are being pinned back to their previous releases.