### PR TITLE
Pin Zenoss 6.1.2 to zenoss-centos-base 1.2.16

### DIFF
--- a/product-base/makefile
+++ b/product-base/makefile
@@ -2,7 +2,7 @@ include ../versions.mk
 IMAGENAME  = product-base
 MATURITY ?= DEV
 BUILD_NUMBER  ?= DEV
-FROM_IMAGE ?= zenoss-centos-base:1.2.12
+FROM_IMAGE ?= zenoss-centos-base:1.2.16
 
 TAG ?= zenoss/$(IMAGENAME):$(VERSION)_$(BUILD_NUMBER)_$(MATURITY)
 


### PR DESCRIPTION
Fixes ZEN-29739.