### PR TITLE
fix mismatch between json file and branch name in repo

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -311,7 +311,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ZaaS.UI",
-        "feature": "localhost-collector",
+        "feature": "localhost_collector",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ZenDeviceACL",


### PR DESCRIPTION
This mismatch was preventing `zendev restore` and `zendev devimg --clean --product cse` from working properly.