### PR TITLE
Use pynetsnmp develop branch build.

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -16,10 +16,11 @@
         "version": "develop"
     },
     {
-        "URL": "http://zenpip.zenoss.eng/packages/{name}-{version}-py2-none-any.whl",
         "name": "pynetsnmp",
-        "type": "download",
-        "version": "0.40.7"
+        "type": "jenkins",
+        "version": "develop",
+        "jenkins.server": "http://jenkins.zenoss.eng",
+        "jenkins.job": "pynetsnmp-develop"
     },
     {
         "URL": "http://zenpip.zenoss.eng/packages/central-query-{version}-zapp.tar.gz",


### PR DESCRIPTION
This build contains the fix for leaked file descriptors when SNMP v3 authentication fails (ZEN-29805).