### PR TITLE
Pin vSphere zenpack to 3.6.3 for Dione.

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -289,7 +289,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.vSphere",
-        "requirement": "ZenPacks.zenoss.vSphere===3.7.0",
+        "requirement": "ZenPacks.zenoss.vSphere===3.6.3",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.WBEM",


### PR DESCRIPTION
Fixes ZEN-30236.