### PR TITLE
Use 0.41.0 release of pynetsnmp.

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -16,10 +16,10 @@
         "version": "develop"
     },
     {
-        "URL": "http://zenpip.zenoss.eng/packages/{name}-{version}-py2-none-any.whl",
         "name": "pynetsnmp",
         "type": "download",
-        "version": "0.40.7"
+        "version": "0.41.0",
+        "URL": "http://zenpip.zenoss.eng/packages/{name}-{version}-py2-none-any.whl"
     },
     {
         "URL": "http://zenpip.zenoss.eng/packages/central-query-{version}-zapp.tar.gz",


### PR DESCRIPTION
This version will not leak open socket descriptors when there's an SNMP v3 authentication error.

Fixes ZEN-30372.