### PR TITLE
Pin Docker to 2.0.4

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -111,10 +111,8 @@
     },
     {
         "name": "ZenPacks.zenoss.Docker",
-        "requirement": "ZenPacks.zenoss.Docker==2.0.*",
-        "git_ref": "hotfix/2.0.4",
-        "type": "zenpack",
-        "pre": true
+        "requirement": "ZenPacks.zenoss.Docker===2.0.4",
+        "type": "zenpack"
     },
     {
         "name": "ZenPacks.zenoss.DurationThreshold",


### PR DESCRIPTION
The only update in 2.0.4 is a fix for a unit test failure on Zenoss 7.