### PR TITLE
ZEN-29878: set default solr log level to WARN

### DIFF
--- a/product-base/install_scripts/zenoss_component_install.sh
+++ b/product-base/install_scripts/zenoss_component_install.sh
@@ -126,6 +126,7 @@ su - zenoss -c "pip install --no-index  /tmp/servicemigration*"
 wget -q http://zenpip.zenoss.eng/packages/zenoss-solr-1.0dev.tgz -O /tmp/zenoss-solr.tgz
 tar -C "/" -xzvf /tmp/zenoss-solr.tgz
 chown -R zenoss:zenoss /var/solr
+su - zenoss -c "echo 'log4j.logger.org.apache.solr=WARN' >> /var/solr/log4j.properties"
 
 # Install Modelindex
 artifactDownload "modelindex"


### PR DESCRIPTION
By default solr log level was set to INFO level, that level was
producing a lot of logs due to this on a large customer env
with a lot of users log files was filling out space.
Setting the default log level to WARN which will reduce the logs
number, the log level can be changed through the solr UI.

[JIRA](https://jira.zenoss.com/browse/ZEN-29878)