### PR TITLE
Tweak pinning syntax for a couple of ZenPacks

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -122,7 +122,7 @@
     {
         "name": "ZenPacks.zenoss.DynamicView",
         "type": "zenpack",
-        "requirement": "ZenPacks.zenoss.DynamicView==1.6.2"
+        "requirement": "ZenPacks.zenoss.DynamicView===1.6.2"
     },
     {
         "name": "ZenPacks.zenoss.EMC.base",
@@ -157,7 +157,7 @@
     {
         "name": "ZenPacks.zenoss.HP.Proliant",
         "type": "zenpack",
-        "requirement": "ZenPacks.zenoss.HP.Proliant==3.3.1"
+        "requirement": "ZenPacks.zenoss.HP.Proliant===3.3.1"
     },
     {
         "name": "ZenPacks.zenoss.HpuxMonitor",


### PR DESCRIPTION
Previous PR missed an extra `=` in the pinning statement