### PR TITLE
bump metric consumer to 0.1.9

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -69,7 +69,7 @@
         "URL": "http://zenpip.zenoss.eng/packages/metric-consumer-app-{version}-zapp.tar.gz",
         "name": "zenoss.metric.consumer",
         "type": "download",
-        "version": "0.1.8"
+        "version": "0.1.9"
     },
     {
         "URL": "http://zenpip.zenoss.eng/packages/{name}-{version}.tgz",


### PR DESCRIPTION
metric consumer 0.1.9 has changes for https://jira.zenoss.com/browse/ZEN-3016, which are also required for https://jira.zenoss.com/browse/ZING-627