### PR TITLE
Pin LinuxMonitor 2.2.7 to RM 6.2.1 release.

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -167,7 +167,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.LinuxMonitor",
-        "requirement": "ZenPacks.zenoss.LinuxMonitor===2.3.1",
+        "requirement": "ZenPacks.zenoss.LinuxMonitor===2.2.7",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Memcached",


### PR DESCRIPTION
Fixes ZEN-30730.

LinuxMonitor 2.3.1 has issues that won't be resolved in time for the 6.2.1 release.