### PR TITLE
Package newest migration for HC changes

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -39,7 +39,7 @@
         "git_owner": "control-center",
         "type": "download",
         "URL": "http://zenpip.zenoss.eng/packages/servicemigration-{version}-py2-none-any.whl",
-        "version": "1.1.11"
+        "version": "1.1.12"
     },
     {
         "URL": "http://zenpip.zenoss.eng/packages/zenoss.extjs-{version}.tar.gz",


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3559

CC-3559 requires an updated service migration release in order to add additional properties to the health checks.