### PR TITLE
Bump zproxy to version 1.0.6

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -82,7 +82,7 @@
         "URL": "http://zenpip.zenoss.eng/packages/{name}-{version}.tar.gz",
         "name": "zproxy",
         "type": "download",
-        "version": "1.0.5"
+        "version": "1.0.6"
     },
     {
         "URL": "http://zenpip.zenoss.eng/packages/{name}-{version}-py2-none-any.whl",


### PR DESCRIPTION
### READY WHEN ZPROXY IS RELEASED
https://jira.zenoss.com/browse/ZEN-30731

Add the new zproxy to support auth0 access tokens in the zapp lua file.