### PR TITLE
Check latest

### DIFF
--- a/Jenkins-begin.groovy
+++ b/Jenkins-begin.groovy
@@ -34,6 +34,10 @@ node('build-zenoss-product') {
 
         stage('Build product-base') {
             if (PINNED == "true") {
+                checkLatest = ""
+                if (CHECK_LATEST == 'true') {
+                    checkLatest = " --check-latest"
+                }
                 // make sure SVCDEF_GIT_REF and IMPACT_VERSION have the form x.x.x, where x is an integer
                 println "Checking for pinned versions in versions.mk"
                 sh("grep '^SVCDEF_GIT_REF=[0-9]\\{1,\\}\\.[0-9]\\{1,\\}\\.[0-9]\\{1,\\}' versions.mk")
@@ -45,10 +49,10 @@ node('build-zenoss-product') {
 
                 // Verify that everything in the component and ZP manifests are pinned
                 println "Checking for pinned versions in component_versions.json"
-                sh("./artifact_download.py component_versions.json --pinned")
+                sh("./artifact_download.py component_versions.json --pinned" + checkLatest)
 
                 println "Checking for pinned versions in zenpack_versions.json"
-                sh("./artifact_download.py zenpack_versions.json --pinned")
+                sh("./artifact_download.py zenpack_versions.json --pinned" + checkLatest)
             }
             sh("cd product-base;MATURITY=${MATURITY} BUILD_NUMBER=${PRODUCT_BUILD_NUMBER} make clean build")
         }

--- a/artifact_download.py
+++ b/artifact_download.py
@@ -337,10 +337,8 @@ def main(options):
             errors.append("unpinned versions found:\n%s" % '\n'.join(unpinned))
         if notLatest:
             msg = "not using latest versions :\n%s" % '\n'.join(notLatest)
-            if options.check_latest:
-                errors.append(msg)
-            else:
-                print "Warning: %s" % msg
+            errors.append(msg)
+
         if errors:
             sys.exit("\n".join(errors))
         sys.exit(0)


### PR DESCRIPTION
ZING-1224

Adds option to check for latest zenpack versions and fails build if manifest doesn't match latest versions

Example failure http://platform-jenkins.zenoss.eng/job/product-assembly/job/develop/job/begin/381/console