### PR TITLE
ZEN-29982: reportmail does not work for graph reports

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -24,8 +24,8 @@
     },
     {
         "name": "query",
-        "type": "download",
-        "version": "0.1.31",
+        "type": "jenkins",
+        "version": "develop",
         "URL": "http://zenpip.zenoss.eng/packages/central-query-{version}-zapp.tar.gz"
     },
     {


### PR DESCRIPTION
pin develop the version to get changes from 
https://github.com/zenoss/query/pull/341