### PR TITLE
ZING-1255: Pin ZenPack manifest to approved released versions

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -208,7 +208,7 @@
     },
     {
         "name": "ZenPacks.zenoss.Layer2",
-        "requirement": "ZenPacks.zenoss.Layer2===1.4.0",
+        "requirement": "ZenPacks.zenoss.Layer2===1.4.1",
         "type": "zenpack"
     },
     {
@@ -218,7 +218,7 @@
     },
     {
         "name": "ZenPacks.zenoss.LinuxMonitor",
-        "requirement": "ZenPacks.zenoss.LinuxMonitor===2.3.1",
+        "requirement": "ZenPacks.zenoss.LinuxMonitor===2.3.2",
         "type": "zenpack"
     },
     {
@@ -368,12 +368,12 @@
     },
     {
         "name": "ZenPacks.zenoss.WBEM",
-        "requirement": "ZenPacks.zenoss.WBEM===2.0.1",
+        "requirement": "ZenPacks.zenoss.WBEM===2.1.0",
         "type": "zenpack"
     },
     {
         "name": "ZenPacks.zenoss.WSMAN",
-        "requirement": "ZenPacks.zenoss.WSMAN===1.0.2",
+        "requirement": "ZenPacks.zenoss.WSMAN===1.0.3",
         "type": "zenpack"
     },
     {


### PR DESCRIPTION
Updated pinnings per comments in ZING-1255:

WSMAN
WBEM
LinuxMonitor
Layer2

Ran artifact_download.py to ensure artifacts exist.

```
csmouse@zenoss-1873-wl:~/src/product-assembly/tmp$ ../artifact_download.py ../zenpack_versions.json ZenPacks.zenoss.WBEM
Downloading http://zenpacks.zenoss.eng/download/ZenPacks.zenoss.WBEM-2.1.0-py2.7.egg
Saving artifact to ./ZenPacks.zenoss.WBEM-2.1.0-py2.7.egg
csmouse@zenoss-1873-wl:~/src/product-assembly/tmp$ ../artifact_download.py ../zenpack_versions.json ZenPacks.zenoss.WSMAN
Downloading http://zenpacks.zenoss.eng/download/ZenPacks.zenoss.WSMAN-1.0.3-py2.7.egg
Saving artifact to ./ZenPacks.zenoss.WSMAN-1.0.3-py2.7.egg
csmouse@zenoss-1873-wl:~/src/product-assembly/tmp$ ../artifact_download.py ../zenpack_versions.json ZenPacks.zenoss.LinuxMonitor
Downloading http://zenpacks.zenoss.eng/download/ZenPacks.zenoss.LinuxMonitor-2.3.2-py2.7.egg
Saving artifact to ./ZenPacks.zenoss.LinuxMonitor-2.3.2-py2.7.egg
csmouse@zenoss-1873-wl:~/src/product-assembly/tmp$ ../artifact_download.py ../zenpack_versions.json ZenPacks.zenoss.Layer2
Downloading http://zenpacks.zenoss.eng/download/ZenPacks.zenoss.Layer2-1.4.1-py2.7.egg
Saving artifact to ./ZenPacks.zenoss.Layer2-1.4.1-py2.7.egg
```
