### PR TITLE
ZEN-30735: Support data point tags for "don't send" and "only send" t…

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -70,7 +70,7 @@
         "URL": "http://zenpip.zenoss.eng/packages/metric-consumer-app-{version}-zapp.tar.gz",
         "name": "zenoss.metric.consumer",
         "type": "download",
-        "version": "0.1.9"
+        "version": "develop"
     },
     {
         "URL": "http://zenpip.zenoss.eng/packages/{name}-{version}.tgz",


### PR DESCRIPTION
…o zing-connector

Pining develop version of the zenoss.metric.consumer to get and test changes
that were made in https://github.com/zenoss/zenoss.metric.consumer/pull/111