### PR TITLE
More 6.3 component pinnings.

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -12,20 +12,20 @@
     },
     {
         "name": "modelindex",
-        "type": "jenkins",
-        "version": "develop"
+        "type": "download",
+        "version": "1.0.4",
+        "URL": "http://zenpip.zenoss.eng/packages/modelindex-{version}.tar.gz"
     },
     {
         "name": "pynetsnmp",
-        "type": "jenkins",
-        "version": "develop",
-        "jenkins.server": "http://jenkins.zenoss.eng",
-        "jenkins.job": "pynetsnmp-develop"
+        "type": "download",
+        "version": "0.41.1",
+        "URL": "http://zenpip.zenoss.eng/packages/pynetsnmp-{version}-py2-none-any.whl"
     },
     {
         "name": "query",
-        "type": "jenkins",
-        "version": "develop",
+        "type": "download",
+        "version": "0.1.33",
         "URL": "http://zenpip.zenoss.eng/packages/central-query-{version}-zapp.tar.gz"
     },
     {
@@ -86,7 +86,8 @@
     },
     {
         "name": "zenoss.toolbox",
-        "type": "jenkins",
-        "version": "develop"
+        "type": "download",
+        "version": "2.3.0",
+        "URL": "http://zenpip.zenoss.eng/packages/zenoss.toolbox-{version}-py2-none-any.whl"
     }
 ]


### PR DESCRIPTION
Components pinned:
- query 0.1.33
- zenoss.toolbox 2.3.0
- pynetsnmp 0.41.1
- modelindex 1.0.4

Fixes BLD-212.