### PR TITLE
Updates for 7.0.8 release.

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -51,8 +51,8 @@
     {
         "URL": "http://zenpip.zenoss.eng/packages/prodbin-{version}-master.tar.gz",
         "name": "zenoss-prodbin",
-        "type": "jenkins",
-        "version": "develop"
+        "type": "download",
+        "version": "7.0.8"
     },
     {
         "URL": "http://zenpip.zenoss.eng/packages/zenoss.protocols-{version}-py2-none-any.whl",

--- a/versions.mk
+++ b/versions.mk
@@ -17,8 +17,8 @@
 # UCSPM_VERSION     the version of the ucspm release; e.g 2.1.0
 #
 SHORT_VERSION=7.0
-SVCDEF_GIT_REF=7.0.7
-VERSION=7.0.7
+SVCDEF_GIT_REF=7.0.8
+VERSION=7.0.8
 VERSION_TAG=1
 
 #

--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -333,8 +333,8 @@
     },
     {
         "name": "ZenPacks.zenoss.RMMonitor",
-        "type": "zenpack",
-        "pre": true
+        "requirement": "ZenPacks.zenoss.RMMonitor===1.1.1",
+        "type": "zenpack"
     },
     {
         "name": "ZenPacks.zenoss.RabbitMQ",


### PR DESCRIPTION
- Pin prodbin to 7.0.8
- Pin ZenPacks.zenoss.RMMonitor back to 1.1.1
- Update versions to 7.0.8