### PR TITLE
Pin prodbin and RMMonitor for 7.0.8

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -51,8 +51,8 @@
     {
         "URL": "http://zenpip.zenoss.eng/packages/prodbin-{version}-master.tar.gz",
         "name": "zenoss-prodbin",
-        "type": "jenkins",
-        "version": "develop"
+        "type": "download",
+        "version": "7.0.8"
     },
     {
         "URL": "http://zenpip.zenoss.eng/packages/zenoss.protocols-{version}-py2-none-any.whl",

--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -333,8 +333,8 @@
     },
     {
         "name": "ZenPacks.zenoss.RMMonitor",
-        "type": "zenpack",
-        "pre": true
+        "requirement": "ZenPacks.zenoss.RMMonitor===1.1.1",
+        "type": "zenpack"
     },
     {
         "name": "ZenPacks.zenoss.RabbitMQ",


### PR DESCRIPTION
- Pin prodbin component to 7.0.8
- Pin ZenPacks.zenoss.RMMonitor back to 1.1.1

Fixes ZING-2046.