### PR TITLE
ZEN-31234 Add automated check of 3rd-party Python packages

### DIFF
--- a/Jenkins-begin.groovy
+++ b/Jenkins-begin.groovy
@@ -134,6 +134,13 @@ node('build-zenoss-product') {
          credentialsId: 'zing-registry-188222', pathPrefix: 'artifacts/', pattern: 'artifacts/*tgz'
         }
 
+        stage('3rd-party Python packages check') {
+            customImage.inside {
+                sh 'pip list --format json > 3rd-party.json'
+            }
+            archive includes: '3rd-party.json'
+        }
+
     } catch (err) {
         echo "Job failed with the following error: ${err}"
         if (err.toString().contains("completed with status ABORTED") ||


### PR DESCRIPTION
This is the first part of fixes for this ticket.
Added step which generates Python's packages list and archive it as build job artifacts.