### PR TITLE
Update install order for CiscoUCS release

### DIFF
--- a/cse/zenpacks.json
+++ b/cse/zenpacks.json
@@ -42,13 +42,14 @@
         "ZenPacks.zenoss.AixMonitor",
         "ZenPacks.zenoss.IBM.Power",
         "ZenPacks.zenoss.AdvancedSearch",
-        "ZenPacks.zenoss.CiscoUCS",
         "ZenPacks.zenoss.ZenOperatorRole",
         "ZenPacks.zenoss.EnterpriseSecurity",
         "ZenPacks.zenoss.Licensing",
         "ZenPacks.zenoss.Microsoft.Windows",
         "ZenPacks.zenoss.DistributedCollector",
         "ZenPacks.zenoss.ComponentGroups",
+        "ZenPacks.zenoss.UCSCapacity",
+        "ZenPacks.zenoss.CiscoUCS",
         "ZenPacks.zenoss.GoogleCloudPlatform",
         "ZenPacks.zenoss.DiscoveryMapping",
         "ZenPacks.zenoss.Kubernetes",
@@ -78,7 +79,6 @@
         "ZenPacks.zenoss.PostgreSQL",
         "ZenPacks.zenoss.RabbitMQ",
         "ZenPacks.zenoss.TomcatMonitor",
-        "ZenPacks.zenoss.UCSCapacity",
         "ZenPacks.zenoss.XenServer"
     ],
     "version_overrides": {}

--- a/cse/zphistory.json
+++ b/cse/zphistory.json
@@ -2,5 +2,6 @@
   "ZenPacks.zenoss.Capacity": "7.0.9",
   "ZenPacks.zenoss.Kubernetes": "7.0.9",
   "ZenPacks.zenoss.RMMonitor": "1.1.1",
-  "ZenPacks.zenoss.ControlCenter": "1.6.2"
+  "ZenPacks.zenoss.ControlCenter": "1.6.2",
+  "ZenPacks.zenoss.UCSCapacity": "0.0.0"
 }


### PR DESCRIPTION
The UCSCapacity ZP is merged into CiscoUCS ZP and is no longer required. This change updates the order of install of these two ZP's where we upgrade UCSCapacity first, if it's installed, and then upgrade CiscoUCS.  