### PR TITLE
Update install order for CiscoUCS release

### DIFF
--- a/cse/zenpacks.json
+++ b/cse/zenpacks.json
@@ -44,7 +44,6 @@
         "ZenPacks.zenoss.IBM.Power",
         "ZenPacks.zenoss.AdvancedSearch",
         "ZenPacks.zenoss.Diagram",
-        "ZenPacks.zenoss.CiscoUCS",
         "ZenPacks.zenoss.ZenOperatorRole",
         "ZenPacks.zenoss.EnterpriseSecurity",
         "ZenPacks.zenoss.Licensing",
@@ -52,9 +51,11 @@
         "ZenPacks.zenoss.DistributedCollector",
         "ZenPacks.zenoss.ControlCenter",
         "ZenPacks.zenoss.ComponentGroups",
+        "ZenPacks.zenoss.UCSCapacity",
+        "ZenPacks.zenoss.CiscoUCS",
         "ZenPacks.zenoss.SupportBundle",
         "ZenPacks.zenoss.RMMonitor",
-	"ZenPacks.zenoss.ZaaS.UI"
+        "ZenPacks.zenoss.ZaaS.UI"
     ],
     "included_not_installed": [
         "ZenPacks.zenoss.BigIpMonitor",

--- a/cse/zphistory.json
+++ b/cse/zphistory.json
@@ -49,6 +49,7 @@
   "ZenPacks.zenoss.StorageBase": "5.0.0",
   "ZenPacks.zenoss.SupportBundle": "5.1.2",
   "ZenPacks.zenoss.TomcatMonitor": "5.0.0",
+  "ZenPacks.zenoss.UCSCapacity": "0.0.0",
   "ZenPacks.zenoss.WBEM": "5.0.0",
   "ZenPacks.zenoss.WSMAN": "6.0.0",
   "ZenPacks.zenoss.WebsphereMonitor": "5.0.0",


### PR DESCRIPTION
The UCSCapacity ZP is merged into CiscoUCS ZP and is no longer required. This change updates the order of install of these two ZP's where we upgrade UCSCapacity first, if it's installed, and then upgrade CiscoUCS.