### PR TITLE
pin ZenPacks with Impact unit tests to hotfix

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -1,8 +1,10 @@
 [
     {
+        "git_ref": "hotfix/4.1.2",
         "name": "ZenPacks.zenoss.AWS",
-        "type": "zenpack",
-        "requirement": "ZenPacks.zenoss.AWS===4.1.1"
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.AWS==4.1.*",
+        "type": "zenpack"
     },
     {
         "name": "ZenPacks.zenoss.AdvancedSearch",
@@ -50,13 +52,17 @@
         "type": "zenpack"
     },
     {
+        "git_ref": "hotfix/5.10.1",
         "name": "ZenPacks.zenoss.CiscoMonitor",
         "pre": true,
+        "requirement": "ZenPacks.zenoss.CiscoMonitor==5.10.*",
         "type": "zenpack"
     },
     {
+        "git_ref": "hotfix/2.8.1",
         "name": "ZenPacks.zenoss.CiscoUCS",
-        "requirement": "ZenPacks.zenoss.CiscoUCS===2.8.0",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.CiscoUCS==2.8.*",
         "type": "zenpack"
     },
     {
@@ -85,8 +91,10 @@
         "type": "zenpack"
     },
     {
+        "git_ref": "hotfix/3.0.1",
         "name": "ZenPacks.zenoss.Dell.PowerEdge",
-        "requirement": "ZenPacks.zenoss.Dell.PowerEdge===3.0.0",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.Dell.PowerEdge==3.0.*",
         "type": "zenpack"
     },
     {
@@ -110,8 +118,10 @@
         "type": "zenpack"
     },
     {
+        "git_ref": "hotfix/2.0.5",
         "name": "ZenPacks.zenoss.Docker",
-        "requirement": "ZenPacks.zenoss.Docker===2.0.4",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.Docker==2.0.*",
         "type": "zenpack"
     },
     {
@@ -125,8 +135,10 @@
         "pre": true
     },
     {
+        "git_ref": "hotfix/2.1.1",
         "name": "ZenPacks.zenoss.EMC.base",
-        "requirement": "ZenPacks.zenoss.EMC.base===2.1.0",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.EMC.base==2.1.*",
         "type": "zenpack"
     },
     {
@@ -155,8 +167,10 @@
         "type": "zenpack"
     },
     {
+        "git_ref": "hotfix/1.0.2",
         "name": "ZenPacks.zenoss.GoogleCloudPlatform",
         "pre": true,
+        "requirement": "ZenPacks.zenoss.GoogleCloudPlatform==1.0.*",
         "type": "zenpack"
     },
     {
@@ -207,8 +221,10 @@
         "type": "zenpack"
     },
     {
+        "git_ref": "hotfix/1.0.2",
         "name": "ZenPacks.zenoss.Kubernetes",
-        "requirement": "ZenPacks.zenoss.Kubernetes===1.0.1",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.Kubernetes==1.0.*",
         "type": "zenpack"
     },
     {
@@ -222,8 +238,10 @@
         "requirement": "ZenPacks.zenoss.Licensing===0.3.0"
     },
     {
+        "git_ref": "hotfix/2.3.3",
         "name": "ZenPacks.zenoss.LinuxMonitor",
         "pre": true,
+        "requirement": "ZenPacks.zenoss.LinuxMonitor==2.3.*",
         "type": "zenpack"
     },
     {
@@ -232,8 +250,10 @@
         "type": "zenpack"
     },
     {
+        "git_ref": "hotfix/2.0.1",
         "name": "ZenPacks.zenoss.Microsoft.Azure",
-        "requirement": "ZenPacks.zenoss.Microsoft.Azure===2.0.0",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.Microsoft.Azure==2.0.*",
         "type": "zenpack"
     },
     {
@@ -427,8 +447,10 @@
         "type": "zenpack"
     },
     {
+        "git_ref": "hotfix/4.0.2",
         "name": "ZenPacks.zenoss.vSphere",
-        "requirement": "ZenPacks.zenoss.vSphere===4.0.1",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.vSphere==4.0.*",
         "type": "zenpack"
     }
 ]


### PR DESCRIPTION
The changes related to ZEN-31678 resulted in most ZenPacks with
DynamicView or Impact unit tests now having failing unit tests. To this
end, they have all received updates in a hotfix branch to make their
unit tests be actually correct, and work with DynamicView 1.7.0 and
Impact 5.4.9.

Once DynamicView 1.7.0 and Impact 5.4.9 are released, these ZenPack
hotfixes can be released. Then we can pin them all back to tagged
releases.

Refs ZEN-31678.