### PR TITLE
use Layer2 hotfix/1.4.3 branch

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -228,8 +228,10 @@
         "type": "zenpack"
     },
     {
+        "git_ref": "hotfix/1.4.3",
         "name": "ZenPacks.zenoss.Layer2",
-        "requirement": "ZenPacks.zenoss.Layer2===1.4.1",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.Layer2==1.4.*",
         "type": "zenpack"
     },
     {


### PR DESCRIPTION
Layer2's impact relationships adapter was found to be a significant
contributor to the time spent building impact relationships in some
environments. A change to optimize this has been added to Layer2's
hotfix/1.4.3 branch.

We're pulling this in prior to releasing and pinning Layer2 1.4.3
because further changes may be desired before the next CZ release.

Refs ZPS-5712.