### PR TITLE
use HP.Proliant hotfix/3.3.3 branch

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -174,8 +174,10 @@
         "type": "zenpack"
     },
     {
+        "git_ref": "hotfix/3.3.3",
         "name": "ZenPacks.zenoss.HP.Proliant",
-        "requirement": "ZenPacks.zenoss.HP.Proliant===3.3.2",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.HP.Proliant==3.3.*",
         "type": "zenpack"
     },
     {


### PR DESCRIPTION
A defect (ZPS-5713) existed in HP Proliant impact relationship providers
that could result in an exception. Any relationship provider that
results in an exception could be responsible for leaving the other side
of the relationship in an uncorroborated state.

Refs ZPS-5713.