### PR TITLE
use ZenPackLib hotfix/2.1.2 branch

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -431,9 +431,11 @@
         "type": "zenpack"
     },
     {
+        "git_ref": "hotfix/2.1.2",
         "name": "ZenPacks.zenoss.ZenPackLib",
-        "type": "zenpack",
-        "requirement": "ZenPacks.zenoss.ZenPackLib===2.1.1"
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.ZenPackLib==2.1.*",
+        "type": "zenpack"
     },
     {
         "name": "ZenPacks.zenoss.ZenSQLTx",


### PR DESCRIPTION
A change in ApplyDataMap going into Zenoss 7.0.12? has resulted in
problem when the same datamaps are reused to model different devices.
This change fixes the one affected unit test in ZenPackLib by having it
regenerate the datamaps for each device.

Refs ZPS-5741.