### PR TITLE
use PythonCollector hotfix/1.10.2 branch

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -351,8 +351,10 @@
         "type": "zenpack"
     },
     {
+        "git_ref": "hotfix/1.10.2",
         "name": "ZenPacks.zenoss.PythonCollector",
-        "requirement": "ZenPacks.zenoss.PythonCollector===1.10.1",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.PythonCollector==1.10.*",
         "type": "zenpack"
     },
     {


### PR DESCRIPTION
A change in ApplyDataMap going into Zenoss 7.0.12? has resulted in a
problem when the same datamap is reused. This change fixes the one
affected unit test in PythonCollector by having it regenerate datamaps
for each use.

Refs ZPS-5763.