### PR TITLE
use SolarisMonitor hotfix/2.5.3 branch

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -363,8 +363,10 @@
         "type": "zenpack"
     },
     {
+        "git_ref": "hotfix/2.5.3",
         "name": "ZenPacks.zenoss.SolarisMonitor",
-        "requirement": "ZenPacks.zenoss.SolarisMonitor===2.5.2",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.SolarisMonitor==2.5.*",
         "type": "zenpack"
     },
     {


### PR DESCRIPTION
SolarisMonitor was found to have impact relationship providers that
provided uncorroborated and otherwise inconsistent impact relationships.
These problem have been corrected in the hotfix/2.5.3 branch.

Refs ZPS-5769.