### PR TITLE
use IBM.Power hotfix/1.1.3 branch

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -191,8 +191,10 @@
         "requirement": "ZenPacks.zenoss.HttpMonitor===3.1.0"
     },
     {
+        "git_ref": "hotfix/1.1.3",
         "name": "ZenPacks.zenoss.IBM.Power",
-        "requirement": "ZenPacks.zenoss.IBM.Power===1.1.2",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.IBM.Power==1.1.*",
         "type": "zenpack"
     },
     {


### PR DESCRIPTION
MySqlMonitor was found to have uncorroborated impact relationship
providers. This has been fixed on the hotfix/1.1.3 branch.

Refs ZPS-5772.