### PR TITLE
use MySqlMonitor hotfix/3.1.1 branch

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -288,8 +288,10 @@
         "type": "zenpack"
     },
     {
+        "git_ref": "hotfix/3.1.1",
         "name": "ZenPacks.zenoss.MySqlMonitor",
-        "requirement": "ZenPacks.zenoss.MySqlMonitor===3.1.0",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.MySqlMonitor==3.1.*",
         "type": "zenpack"
     },
     {


### PR DESCRIPTION
MySqlMonitor was found to be providing uncorroborated impact
relationships. Its hotfix/3.1.1 branch has a fix for this.

Refs ZPS-5774.