### PR TITLE
use NetAppMonitor hotfix/4.0.1 branch

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -302,8 +302,10 @@
         "type": "zenpack"
     },
     {
+        "git_ref": "hotfix/4.0.1",
         "name": "ZenPacks.zenoss.NetAppMonitor",
-        "requirement": "ZenPacks.zenoss.NetAppMonitor===3.7.0",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.NetAppMonitor==4.0.*",
         "type": "zenpack"
     },
     {


### PR DESCRIPTION
The NetAppMonitor ZenPack was found to be providing duplicate and
uncorroborated impact relationships. These have been corrected in the
hotfix/4.0.1 branch.

Refs ZPS-5779.