### PR TITLE
update ZenPacks to fix ADM unit test failures

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -40,8 +40,10 @@
         "requirement": "ZenPacks.zenoss.CiscoMonitor===5.9.0",
         "type": "zenpack"
     },{
+        "git_ref": "hotfix/2.8.1",
         "name": "ZenPacks.zenoss.CiscoUCS",
-        "requirement": "ZenPacks.zenoss.CiscoUCS===2.8.0",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.CiscoUCS==2.8.*",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCSCentral",
@@ -172,8 +174,10 @@
         "requirement": "ZenPacks.zenoss.Licensing===0.3.0",
         "type": "zenpack"
     },{
+        "git_ref": "hotfix/2.3.3",
         "name": "ZenPacks.zenoss.LinuxMonitor",
-        "requirement": "ZenPacks.zenoss.LinuxMonitor===2.3.2",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.LinuxMonitor==2.3.*",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Memcached",
@@ -256,8 +260,10 @@
         "requirement": "ZenPacks.zenoss.PropertyMonitor===1.1.1",
         "type": "zenpack"
     },{
+        "git_ref": "hotfix/1.10.2",
         "name": "ZenPacks.zenoss.PythonCollector",
-        "requirement": "ZenPacks.zenoss.PythonCollector===1.10.1",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.PythonCollector==1.10.*",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.RabbitMQ",
@@ -296,8 +302,10 @@
         "requirement": "ZenPacks.zenoss.vCloud===1.4.9",
         "type": "zenpack"
     },{
+        "git_ref": "hotfix/4.0.2",
         "name": "ZenPacks.zenoss.vSphere",
-        "requirement": "ZenPacks.zenoss.vSphere===4.0.0",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.vSphere==4.0.*",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.WBEM",
@@ -336,8 +344,10 @@
         "requirement": "ZenPacks.zenoss.ZenOperatorRole===2.2.0",
         "type": "zenpack"
     },{
+        "git_ref": "hotfix/2.1.2",
         "name": "ZenPacks.zenoss.ZenPackLib",
-        "requirement": "ZenPacks.zenoss.ZenPackLib===2.1.1",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.ZenPackLib==2.1.*",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ZenSQLTx",


### PR DESCRIPTION
The ApplyDataMap changes introduced under ZEN-31166 caused some ZenPack
unit tests to break. These ZenPack unit tests have been fixed in hotfix
branches, and are pending release. We need to include them in the build
to ensure that the fixes were successful.

Refs ZEN-31166.