### PR TITLE
Pin ZenPacks.zenoss.Dashboard to 1.3.7 release.

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -76,8 +76,8 @@
     },
     {
         "name": "ZenPacks.zenoss.Dashboard",
-        "type": "zenpack",
-        "pre": true
+        "requirement": "ZenPacks.zenoss.Dashboard===1.3.7",
+        "type": "zenpack"
     },
     {
         "name": "ZenPacks.zenoss.DatabaseMonitor",


### PR DESCRIPTION
Fixes ZEN-31840.