### PR TITLE
Pin DistributedCollector to 3.1.8 release.

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -101,7 +101,7 @@
     },
     {
         "name": "ZenPacks.zenoss.DistributedCollector",
-        "pre": true,
+        "requirement": "ZenPacks.zenoss.DistributedCollector===3.1.8",
         "type": "zenpack"
     },
     {


### PR DESCRIPTION
Fixes ZEN-31838.