### PR TITLE
use PythonCollector develop (1.11.0) branch

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -359,10 +359,10 @@
         "type": "zenpack"
     },
     {
-        "git_ref": "hotfix/1.10.2",
+        "git_ref": "develop",
         "name": "ZenPacks.zenoss.PythonCollector",
         "pre": true,
-        "requirement": "ZenPacks.zenoss.PythonCollector==1.10.*",
+        "requirement": "ZenPacks.zenoss.PythonCollector==1.11.*",
         "type": "zenpack"
     },
     {


### PR DESCRIPTION
Switching from hotfix/1.10.2 to develop (1.11.0) because QA is going to
focus on testing and releasing 1.11.0 instead of 1.10.2.

Refs ZPS-5763.