### PR TITLE
Pin EnterpriseCollector to its 1.9.0 release.

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -131,7 +131,7 @@
     },
     {
         "name": "ZenPacks.zenoss.EnterpriseCollector",
-        "pre": true,
+        "requirement": "ZenPacks.zenoss.EnterpriseCollector===1.9.0",
         "type": "zenpack"
     },
     {


### PR DESCRIPTION
Fixes ZEN-31837.