### PR TITLE
Pin zenoss-services to 7.0.12 release.

### DIFF
--- a/versions.mk
+++ b/versions.mk
@@ -17,7 +17,7 @@
 # UCSPM_VERSION     the version of the ucspm release; e.g 2.1.0
 #
 SHORT_VERSION=7.0
-SVCDEF_GIT_REF=release/7.0.12
+SVCDEF_GIT_REF=7.0.12
 VERSION=7.0.12
 VERSION_TAG=1
 


### PR DESCRIPTION
Fixes ZEN-31658.