### PR TITLE
Pin zenoss-prodbin to its 7.0.12 release.

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -49,7 +49,7 @@
         "version": "4.1.3"
     },
     {
-        "URL": "http://zenpip.zenoss.eng/packages/prodbin-{version}-rc.tar.gz",
+        "URL": "http://zenpip.zenoss.eng/packages/prodbin-{version}-master.tar.gz",
         "name": "zenoss-prodbin",
         "type": "download",
         "version": "7.0.12"


### PR DESCRIPTION
Fixes ZEN-31654.