### PR TITLE
ZEN-31557: Add FTPMonitor to the  Zenpack manifest

### DIFF
--- a/core/zenpacks.json
+++ b/core/zenpacks.json
@@ -16,6 +16,7 @@
   ],
   "included_not_installed": [
     "ZenPacks.zenoss.DnsMonitor",
+    "ZenPacks.zenoss.FtpMonitor",
     "ZenPacks.zenoss.LDAPMonitor"
   ],
   "version_overrides": {}

--- a/cse/zenpacks.json
+++ b/cse/zenpacks.json
@@ -62,6 +62,7 @@
         "ZenPacks.zenoss.CiscoAPIC",
         "ZenPacks.zenoss.DatabaseMonitor",
         "ZenPacks.zenoss.DB2",
+        "ZenPacks.zenoss.FtpMonitor",
         "ZenPacks.zenoss.HpuxMonitor",
         "ZenPacks.zenoss.JBossMonitor",
         "ZenPacks.zenoss.Layer2",

--- a/cse/zphistory.json
+++ b/cse/zphistory.json
@@ -24,6 +24,7 @@
   "ZenPacks.zenoss.EnterpriseReports": "5.0.0",
   "ZenPacks.zenoss.EnterpriseSecurity": "5.0.0",
   "ZenPacks.zenoss.EnterpriseSkin": "5.0.0",
+  "ZenPacks.zenoss.FtpMonitor": "5.0.0",
   "ZenPacks.zenoss.HP.Proliant": "6.0.0",
   "ZenPacks.zenoss.HpuxMonitor": "5.0.0",
   "ZenPacks.zenoss.HttpMonitor": "5.0.0",

--- a/resmgr/zenpacks.json
+++ b/resmgr/zenpacks.json
@@ -61,6 +61,7 @@
         "ZenPacks.zenoss.CiscoAPIC",
         "ZenPacks.zenoss.DatabaseMonitor",
         "ZenPacks.zenoss.DB2",
+        "ZenPacks.zenoss.FtpMonitor",
         "ZenPacks.zenoss.GoogleCloudPlatform",
         "ZenPacks.zenoss.HpuxMonitor",
         "ZenPacks.zenoss.JBossMonitor",

--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -122,6 +122,10 @@
         "requirement": "ZenPacks.zenoss.EnterpriseSkin===3.3.5",
         "type": "zenpack"
     },{
+        "name": "ZenPacks.zenoss.FtpMonitor",
+        "requirement": "ZenPacks.zenoss.FtpMonitor===1.1.1",
+        "type": "zenpack"
+    },{
         "name": "ZenPacks.zenoss.GoogleCloudPlatform",
         "requirement": "ZenPacks.zenoss.GoogleCloudPlatform===1.0.0",
         "type": "zenpack"


### PR DESCRIPTION
backport https://github.com/zenoss/product-assembly/pull/903