### PR TITLE
ZEN-31756: update ZenPacks for Impact 5.5

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -25,11 +25,11 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CalculatedPerformance",
-        "requirement": "ZenPacks.zenoss.CalculatedPerformance===2.5.1",
+        "requirement": "ZenPacks.zenoss.CalculatedPerformance===2.5.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Ceph",
-        "requirement": "ZenPacks.zenoss.Ceph===2.0.1",
+        "requirement": "ZenPacks.zenoss.Ceph===2.1.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoAPIC",
@@ -40,10 +40,8 @@
         "requirement": "ZenPacks.zenoss.CiscoMonitor===5.9.0",
         "type": "zenpack"
     },{
-        "git_ref": "hotfix/2.8.1",
         "name": "ZenPacks.zenoss.CiscoUCS",
-        "pre": true,
-        "requirement": "ZenPacks.zenoss.CiscoUCS==2.8.*",
+        "requirement": "ZenPacks.zenoss.CiscoUCS===2.8.1",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCSCentral",
@@ -51,7 +49,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ComponentGroups",
-        "requirement": "ZenPacks.zenoss.ComponentGroups===1.7.0",
+        "requirement": "ZenPacks.zenoss.ComponentGroups===1.8.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.ControlCenter",
@@ -99,7 +97,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DynamicView",
-        "requirement": "ZenPacks.zenoss.DynamicView===1.6.2",
+        "requirement": "ZenPacks.zenoss.DynamicView===1.7.0",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.EMC.base",
@@ -139,7 +137,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.IBM.Power",
-        "requirement": "ZenPacks.zenoss.IBM.Power===1.1.2",
+        "requirement": "ZenPacks.zenoss.IBM.Power===1.1.3",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.InstalledTemplatesReport",
@@ -159,7 +157,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Layer2",
-        "requirement": "ZenPacks.zenoss.Layer2===1.4.0",
+        "requirement": "ZenPacks.zenoss.Layer2===1.4.3",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.LDAPAuthenticator",
@@ -174,10 +172,8 @@
         "requirement": "ZenPacks.zenoss.Licensing===0.3.0",
         "type": "zenpack"
     },{
-        "git_ref": "hotfix/2.3.3",
         "name": "ZenPacks.zenoss.LinuxMonitor",
-        "pre": true,
-        "requirement": "ZenPacks.zenoss.LinuxMonitor==2.3.*",
+        "requirement": "ZenPacks.zenoss.LinuxMonitor===2.3.3",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.Memcached",
@@ -260,10 +256,8 @@
         "requirement": "ZenPacks.zenoss.PropertyMonitor===1.1.1",
         "type": "zenpack"
     },{
-        "git_ref": "hotfix/1.10.2",
         "name": "ZenPacks.zenoss.PythonCollector",
         "pre": true,
-        "requirement": "ZenPacks.zenoss.PythonCollector==1.10.*",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.RabbitMQ",
@@ -302,10 +296,8 @@
         "requirement": "ZenPacks.zenoss.vCloud===1.4.9",
         "type": "zenpack"
     },{
-        "git_ref": "hotfix/4.0.2",
         "name": "ZenPacks.zenoss.vSphere",
-        "pre": true,
-        "requirement": "ZenPacks.zenoss.vSphere==4.0.*",
+        "requirement": "ZenPacks.zenoss.vSphere===4.0.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.WBEM",


### PR DESCRIPTION
- CalculatedPerformance 2.5.2
- Ceph 2.1.0
- CiscoUCS 2.8.1
- ComponentGroups 1.8.0
- DynamicView 1.7.0
- IBM.Power 1.1.3
- Layer2 1.4.2
- LinuxMonitor 2.3.3
- PythonCollector 1.11.0.dev
- vSphere 4.0.2