### PR TITLE
ZEN-31909: 6.x product-assembly begin failed with unit test failures

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -97,7 +97,7 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DynamicView",
-        "requirement": "ZenPacks.zenoss.DynamicView===1.7.0",
+        "requirement": "ZenPacks.zenoss.DynamicView===1.6.2",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.EMC.base",
@@ -260,8 +260,10 @@
         "requirement": "ZenPacks.zenoss.PropertyMonitor===1.1.1",
         "type": "zenpack"
     },{
+        "git_ref": "hotfix/1.10.2",
         "name": "ZenPacks.zenoss.PythonCollector",
         "pre": true,
+        "requirement": "ZenPacks.zenoss.PythonCollector==1.10.*",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.RabbitMQ",


### PR DESCRIPTION
Reverting pins for
ZenPacks.zenoss.DynamicView
ZenPacks.zenoss.PythonCollector
to get a build.
Working on failing tests