### PR TITLE
ZEN-31909: fix ZenPack unit test problems

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -36,8 +36,10 @@
         "requirement": "ZenPacks.zenoss.CiscoAPIC===1.2.3",
         "type": "zenpack"
     },{
+        "git_ref": "hotfix/5.10.1",
         "name": "ZenPacks.zenoss.CiscoMonitor",
-        "requirement": "ZenPacks.zenoss.CiscoMonitor===5.9.0",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.CiscoMonitor==5.10.*",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.CiscoUCS",
@@ -88,8 +90,10 @@
         "requirement": "ZenPacks.zenoss.DnsMonitor===3.0.1",
         "type": "zenpack"
     },{
+        "git_ref": "hotfix/2.0.5",
         "name": "ZenPacks.zenoss.Docker",
-        "requirement": "ZenPacks.zenoss.Docker===2.0.4",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.Docker==2.0.*",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.DurationThreshold",
@@ -100,8 +104,10 @@
         "requirement": "ZenPacks.zenoss.DynamicView===1.7.0",
         "type": "zenpack"
     },{
+        "git_ref": "hotfix/2.1.1",
         "name": "ZenPacks.zenoss.EMC.base",
-        "requirement": "ZenPacks.zenoss.EMC.base===2.1.0",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.EMC.base==2.1.*",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.EnterpriseCollector",
@@ -212,8 +218,10 @@
         "requirement": "ZenPacks.zenoss.MySqlMonitor===3.1.0",
         "type": "zenpack"
     },{
+        "git_ref": "hotfix/4.0.1",
         "name": "ZenPacks.zenoss.NetAppMonitor",
-        "requirement": "ZenPacks.zenoss.NetAppMonitor===3.6.0",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.NetAppMonitor==4.0.*",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.NetScaler",


### PR DESCRIPTION
Upgrading to DynamicView 1.7.0 in 77c6fc7 resulted in the following
ZenPack unit test errors and failures.

    Tests with errors:
       test_DynamicView (ZenPacks.zenoss.CiscoMonitor.tests.test_dvi.TestCiscoMonitor_DVI)
       test_DynamicView (ZenPacks.zenoss.Docker.tests.test_dvi.DVITests)

    Tests with failures:
       test_dv_consistent (ZenPacks.zenoss.EMC.base.tests.test_dynamicview.TestDynamicView)
       test_onSuccess (ZenPacks.zenoss.NetAppMonitor.tests.testMonitoring.Test7ModeMonitoring)
       test_onSuccess (ZenPacks.zenoss.NetAppMonitor.tests.testMonitoring.TestCModeMonitoring)

These test problems should be corrected in the latest hotfix branches of
the associated ZenPacks. So I'm pulling in those hotfix builds. These
hotfixes will need to be released and pinned here later.

Fixes ZEN-31909.