### PR TITLE
Use RMMonitor 1.2.0 unstable builds.

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -269,7 +269,8 @@
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.RMMonitor",
-        "requirement": "ZenPacks.zenoss.RMMonitor===1.1.1",
+        "pre": true,
+        "requirement": "ZenPacks.zenoss.RMMonitor==1.2.*",
         "type": "zenpack"
     },{
         "name": "ZenPacks.zenoss.SolarisMonitor",


### PR DESCRIPTION
Since RMMonitor 1.2.0 is scheduled for inclusion in RM 6.4.0, use the RMMonitor 1.2.0 unstable builds for the Zenoss 6.4 unstable builds.

ZEN-31782