### PR TITLE
Use 0.1.12 release of metric-consumer.

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -65,7 +65,7 @@
         "URL": "http://zenpip.zenoss.eng/packages/metric-consumer-app-{version}-zapp.tar.gz",
         "name": "zenoss.metric.consumer",
         "type": "download",
-        "version": "0.1.11"
+        "version": "0.1.12"
     },
     {
         "URL": "http://zenpip.zenoss.eng/packages/{name}-{version}.tgz",


### PR DESCRIPTION
Fixes ZEN-32241.