### PR TITLE
ZEN-32335: bump centos-base version to 1.2.23

### DIFF
--- a/product-base/makefile
+++ b/product-base/makefile
@@ -2,7 +2,7 @@ include ../versions.mk
 IMAGENAME  = product-base
 MATURITY ?= DEV
 BUILD_NUMBER  ?= DEV
-FROM_IMAGE ?= zenoss-centos-base:1.2.21
+FROM_IMAGE ?= zenoss-centos-base:1.2.23
 
 TAG ?= zenoss/$(IMAGENAME):$(VERSION)_$(BUILD_NUMBER)_$(MATURITY)_CSE
 


### PR DESCRIPTION
fixes: ZEN-32335