### PR TITLE
Pin zenoss-zep to the 2.7.3 release.

### DIFF
--- a/component_versions.json
+++ b/component_versions.json
@@ -57,9 +57,9 @@
     },
     {
         "name": "zenoss-zep",
-        "type": "jenkins",
-        "version": "develop",
-        "jenkins.jobURL": "http://platform-jenkins.zenoss.eng/job/Components/job/zenoss-zep/job/develop/"
+        "version": "2.7.3",
+        "type": "download",
+        "URL": "http://zenpip.zenoss.eng/packages/zep-dist-{version}.tar.gz"
     },
     {
         "jenkins.jobURL": "http://platform-jenkins.zenoss.eng/job/Components/job/zenoss.metric.consumer/job/develop/",


### PR DESCRIPTION
Fixes ZEN-32369.