### PR TITLE
Use zenoss-centos-base 1.2.24 image for CZ builds.

### DIFF
--- a/product-base/makefile
+++ b/product-base/makefile
@@ -2,7 +2,7 @@ include ../versions.mk
 IMAGENAME  = product-base
 MATURITY ?= DEV
 BUILD_NUMBER  ?= DEV
-FROM_IMAGE ?= zenoss-centos-base:1.2.23
+FROM_IMAGE ?= zenoss-centos-base:1.2.24
 
 TAG ?= zenoss/$(IMAGENAME):$(VERSION)_$(BUILD_NUMBER)_$(MATURITY)_CSE
 


### PR DESCRIPTION
Fixes ZEN-32435.