### PR TITLE
Roll back EnterpriseSecurity to the 1.2.0 release.

### DIFF
--- a/zenpack_versions.json
+++ b/zenpack_versions.json
@@ -146,7 +146,7 @@
     },
     {
         "name": "ZenPacks.zenoss.EnterpriseSecurity",
-        "requirement": "ZenPacks.zenoss.EnterpriseSecurity===2.0.1",
+        "requirement": "ZenPacks.zenoss.EnterpriseSecurity===1.2.0",
         "type": "zenpack"
     },
     {


### PR DESCRIPTION
Fixes ZEN-32427.