### PR TITLE
ZEN-32652 Services 'mariadb-model' and 'mariadb-events' don't start a…

### DIFF
--- a/resmgr/upgrade-resmgr.sh.in
+++ b/resmgr/upgrade-resmgr.sh.in
@@ -60,9 +60,9 @@ then
 MIGRATE_MARIADB_SERVICES="SVC_STOP Zenoss.resmgr/Infrastructure/mariadb-model\\
 SVC_STOP Zenoss.resmgr/Infrastructure/mariadb-events\\
 SVC_WAIT Zenoss.resmgr/Infrastructure/mariadb-events Zenoss.resmgr/Infrastructure/mariadb-model stopped 600\\
-SVC_USE zenoss/mariadb:10.1-%VERSION%_%VERSION_TAG% zenoss/resmgr_6.0 zenoss/resmgr_6.1 zenoss/resmgr_6.2 zenoss/resmgr_6.3 zenoss/resmgr_6.4 service Zenoss.resmgr/Infrastructure/mariadb-model\\
+SVC_USE zenoss/mariadb:10.1-%VERSION%_%VERSION_TAG% zenoss/resmgr_6.0 zenoss/resmgr_6.1 zenoss/resmgr_6.2 zenoss/resmgr_6.3 zenoss/resmgr_6.4 zenoss/resmgr_6.5 service Zenoss.resmgr/Infrastructure/mariadb-model\\
 SVC_EXEC NO_COMMIT 'Zenoss.resmgr/Infrastructure/mariadb-model' /bin/bash -c 'chown -R mysql:mysql /var/lib/mysql; mysqld_safe \& until mysqladmin ping 2>/dev/null; do echo \"Waiting for mysql...\"; sleep 1; done \&\& mysql_upgrade'\\
-SVC_USE zenoss/mariadb:10.1-%VERSION%_%VERSION_TAG% zenoss/resmgr_6.0 zenoss/resmgr_6.1 zenoss/resmgr_6.2 zenoss/resmgr_6.3 zenoss/resmgr_6.4 service Zenoss.resmgr/Infrastructure/mariadb-events\\
+SVC_USE zenoss/mariadb:10.1-%VERSION%_%VERSION_TAG% zenoss/resmgr_6.0 zenoss/resmgr_6.1 zenoss/resmgr_6.2 zenoss/resmgr_6.3 zenoss/resmgr_6.4 service zenoss/resmgr_6.5 Zenoss.resmgr/Infrastructure/mariadb-events\\
 SVC_EXEC NO_COMMIT 'Zenoss.resmgr/Infrastructure/mariadb-events' /bin/bash -c 'chown -R mysql:mysql /var/lib/mysql; mysqld_safe \& until mysqladmin ping 2>/dev/null; do echo \"Waiting for mysql...\"; sleep 1; done \&\& mysql_upgrade'"
 fi
 


### PR DESCRIPTION
…fter Zenoss RM upgrade from version <= 6.3.2 to 6.5.0