### PR TITLE
The 'zendev test' command works again.

### DIFF
--- a/devimg/create_devimg.sh
+++ b/devimg/create_devimg.sh
@@ -60,6 +60,9 @@ EOF
 # Copy the devimg version of prepare.sh into the install_scripts directory.
 cp ${SRCROOT}/product-assembly/devimg/prepare.sh ${ZENHOME}/install_scripts/prepare.sh
 
+# Copy the zendev test --interactive shell script to the install_scripts dir
+cp ${SRCROOT}/product-assembly/devimg/devtestshell.sh ${ZENHOME}/install_scripts/
+
 cat /home/zenoss/.bashrc
 echo "Install Zenoss ..."
 export BUILD_DEVIMG=1

--- a/devimg/devtestshell.sh
+++ b/devimg/devtestshell.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 #
-# Start Zenoss and run all platform and ZenPack tests
+# Configure the environment and start a shell
 #
-
-set -e
 
 # prepare the environment
 source ${ZENHOME}/install_scripts/prepare.sh
@@ -24,4 +22,4 @@ start_redis
 start_rabbitmq
 start_zep
 
-su - zenoss -l -c "${ZENHOME}/bin/runtests $*"
+/bin/bash

--- a/product-base/install_scripts/install_lib.sh
+++ b/product-base/install_scripts/install_lib.sh
@@ -35,47 +35,46 @@ stop_redis() {
 export SOLR_PORT="8983"
 
 start_solr() {
-	printf "Starting solr on port ${SOLR_PORT}..."
-	local cmd="/opt/solr/zenoss/bin/start-solr -cloud -Dbootstrap_confdir=/opt/solr/server/solr/configsets/zenoss_model/conf -Dcollection.configName=zenoss_model -Dsolr.jetty.request.header.size=1000000"
+	echo "Starting solr on port ${SOLR_PORT}..."
+	local solr_cmd="/opt/solr/zenoss/bin/start-solr -cloud -Dbootstrap_confdir=/opt/solr/server/solr/configsets/zenoss_model/conf -Dcollection.configName=zenoss_model -Dsolr.jetty.request.header.size=1000000"
 	if [[ $EUID -eq 0 ]]; then
-		cmd="setuser zenoss ${cmd}"
+		solr_cmd="setuser zenoss ${solr_cmd}"
 	fi
-	eval ${cmd} &
-	# setuser zenoss /opt/solr/zenoss/bin/start-solr -cloud -Dbootstrap_confdir=/opt/solr/server/solr/configsets/zenoss_model/conf -Dcollection.configName=zenoss_model -Dsolr.jetty.request.header.size=1000000 &
+	eval ${solr_cmd} &
 	export SOLR_PID=$!
 	until $(curl -A 'Solr answering healthcheck' -sI http://localhost:$SOLR_PORT/solr/admin/cores | grep -q 200); do
 		sleep 5
 	done
-	echo "OK"
+	echo "Solr has started"
 }
 
 stop_solr() {
-	printf "Stopping solr..."
+	echo "Stopping solr..."
 	kill $SOLR_PID
 	until [[ ! $(ps h -q $SOLR_PID) ]]; do
 		sleep 1
 	done
-	echo "OK"
+	echo "Solr has stopped"
 }
 
 start_zep() {
 	printf "Starting zeneventserver..."
-	local cmd="${ZENHOME}/bin/zeneventserver start"
+	local zep_cmd="${ZENHOME}/bin/zeneventserver start"
 	if [[ $EUID -eq 0 ]]; then
-		cmd="su - zenoss -c \"${cmd}\""
+		zep_cmd="su - zenoss -c \"${zep_cmd}\""
 	fi
-	eval ${cmd}
-	echo "OK"
+	eval ${zep_cmd}
+	echo "zeneventserver has started"
 }
 
 stop_zep() {
-	printf "Stopping zeneventserver..."
-	local cmd="${ZENHOME}/bin/zeneventserver stop"
+	echo "Stopping zeneventserver..."
+	local zep_cmd="${ZENHOME}/bin/zeneventserver stop"
 	if [[ $EUID -eq 0 ]]; then
-		cmd="su - zenoss -c \"${cmd}\""
+		zep_cmd="su - zenoss -c \"${zep_cmd}\""
 	fi
-	eval ${cmd}
-	echo "OK"
+	eval ${zep_cmd}
+	echo "zeneventserver has stopped"
 }
 
 sync_zope_conf() {


### PR DESCRIPTION
This also requires a zendev update so that it calls the test_image.sh script.

Fixes ZEN-32746.