### PR TITLE
Enable the installation wizard.

### DIFF
--- a/build_images.sh
+++ b/build_images.sh
@@ -108,7 +108,7 @@ docker container exec \
 	-w /opt/zenoss/install_scripts \
 	-e "DBHOST=${mariadb_name}" \
 	${product_name} \
-	/bin/bash -l -c "./create_zenoss.sh --no-quickstart" \
+	/bin/bash -l -c "./create_zenoss.sh" \
 	|| fail "Could not execute create_zenoss.sh script"
 
 echo

--- a/resmgr/makefile
+++ b/resmgr/makefile
@@ -1,5 +1,4 @@
 TARGET_PRODUCT = resmgr
 ADDITIONAL_UPGRADE_SCRIPTS = upgrade-impact.txt
 
-include ../versions.mk
 include ../common.mk


### PR DESCRIPTION
The --no-quickstart option tells the build process is to disable the installation wizard.

Fixes ZEN-32779.