### PR TITLE
Run zenmigrate as part of build.

### DIFF
--- a/product-base/install_scripts/create_zenoss.sh
+++ b/product-base/install_scripts/create_zenoss.sh
@@ -52,6 +52,9 @@ su - zenoss -c "${ZENHOME}/bin/zendmd --script ${ZENHOME}/bin/addSystemUser.py"
 # link installs for zendev/devimg
 ensure_dfs_dirs
 
+# Migrate ZODB
+migrate_zodb
+
 install_zenpacks
 
 # Pass along arguments to this function (e.g. --no-quickstart)

--- a/product-base/install_scripts/databases_lib.sh
+++ b/product-base/install_scripts/databases_lib.sh
@@ -53,6 +53,15 @@ load_zodb() {
 		|| die "Unable to load Zenoss ZODB SQL dump"
 }
 
+migrate_zodb() {
+	echo "Migrating ZODB..."
+	local cmd="zenmigrate --dont-bump"
+	if [[ $EUID -eq 0 ]]; then
+		cmd="su - zenoss -c \"${cmd}\""
+	fi
+	eval ${cmd} || die "Unable to migrate ZODB"
+}
+
 pack_zodb() {
 	echo "Packing the ZODB database..."
 	local cmd="zodbpack ${ZENHOME}/install_scripts/zodbpack.conf"


### PR DESCRIPTION
Applies ZODB migrations without having to update the zodb.sql.gz data dump.  The dump will happen when prodbin is released.

Fixes ZEN-33055.