### PR TITLE
Make service template builds consistent.

### DIFF
--- a/Jenkins-begin.groovy
+++ b/Jenkins-begin.groovy
@@ -198,11 +198,12 @@ node('build-zenoss-product') {
         }
 
         stage("Build service template package") {
+            def repo_dir = ""
             // Run the checkout in a separate directory.
             dir("svcdefs") {
                 // We have to clean it ourselves, because Jenkins doesn't (apparently)
                 sh("make clean")
-                def repo_dir = sh(returnStdout: true, script: "make repo_dir").trim()
+                repo_dir = sh(returnStdout: true, script: "make repo_dir").trim()
                 dir("${repo_dir}") {
                     echo "Cloning zenoss-service - ${SVCDEF_GIT_REF} with credentialsId=${GIT_CREDENTIAL_ID}"
                     // NOTE: The 'master' branch name here is only used to clone the github repo.
@@ -223,13 +224,14 @@ node('build-zenoss-product') {
                     "BUILD_NUMBER=${PRODUCT_BUILD_NUMBER}",
                     "IMAGE_NUMBER=${PRODUCT_BUILD_NUMBER}",
                     "MATURITY=${MATURITY}",
+                    "SVCDEF_GIT_READY=true",
                     "TARGET_PRODUCT=${TARGET_PRODUCT}"
                 ]) {
                     sh("make build")
                 }
             }
             sh("mkdir -p artifacts")
-            sh("cp svcdefs/src/zenoss-service/output/*.json artifacts/.")
+            sh("cp svcdefs/${repo_dir}/output/*.json artifacts/.")
             dir("artifacts") {
                 sh("for file in *json; do tar -cvzf \$file.tgz \$file; done")
             }


### PR DESCRIPTION
The Jenkins-begin.groovy and Jenkins-promote.groovy scripts now build the service template package the same way.

Fixes ZEN-33302.