### PR TITLE
Clean up mariadb permissions during upgrade.

### DIFF
--- a/mariadb-base/fix_permissions.sql.in
+++ b/mariadb-base/fix_permissions.sql.in
@@ -1,0 +1,18 @@
+# Delete anonymous users
+DELETE FROM mysql.user WHERE user = '';
+
+# Remove remote access from root user
+DELETE FROM mysql.user WHERE user = 'root' and host != 'localhost';
+
+# Allow access from any host for zenoss user
+DELETE FROM mysql.user WHERE user = '!ZU!' and host != '%';
+
+# Grant privileges to zodb and zep users.
+GRANT SELECT ON mysql.proc TO '!ZU!';
+GRANT REPLICATION SLAVE ON *.* TO '!ZU!';
+GRANT PROCESS ON *.* TO '!ZU!';
+GRANT ALL ON zodb.* TO '!ZU!';
+GRANT ALL ON zodb_session.* TO '!ZU!';
+GRANT ALL ON zenoss_zep.* TO '!EU!';
+
+FLUSH PRIVILEGES;

--- a/mariadb-base/makefile
+++ b/mariadb-base/makefile
@@ -32,7 +32,9 @@ dirs = exported_files exported_files/opt/zenoss/bin exported_files/home/zenoss e
 
 toolbox_wheel = zends.toolbox-$(VERSION)-py2-none-any.whl
 etc_files = exported_files/etc/my.cnf
-zenoss_bin_files = exported_files/opt/zenoss/bin/upgrade_database.sh
+
+upgrade_files = fix_permissions.sql.in upgrade_database.sh
+zenoss_bin_files := $(addprefix exported_files/opt/zenoss/bin/,$(upgrade_files))
 
 initialize_files = permissions.sql initialize_db.sh
 home_zenoss_files := $(addprefix exported_files/home/zenoss/,$(initialize_files))

--- a/mariadb-base/upgrade_database.sh
+++ b/mariadb-base/upgrade_database.sh
@@ -5,9 +5,8 @@ GLOBAL_CFG="/opt/zenoss/etc/global.conf"
 ADMIN_USER="root"
 export MYSQL_PWD=""
 
-
 case $SERVICE in
-	mariadb-model)
+	mariadb-model|mariadb)
 		ADMIN_USER=$(grep -r "zodb-admin-user" $GLOBAL_CFG | awk '{print $2}')
 		MYSQL_PWD=$(grep -r "zodb-admin-password" $GLOBAL_CFG | awk '{print $2}')
 		;;
@@ -16,6 +15,9 @@ case $SERVICE in
 		MYSQL_PWD=$(grep -r "zep-admin-password" $GLOBAL_CFG | awk '{print $2}')
 		;;
 esac
+
+ZODB_USER=$(grep -r "zodb-user" $GLOBAL_CFG | awk '{print $2}')
+ZEP_USER=$(grep -r "zep-user" $GLOBAL_CFG | awk '{print $2}')
 
 start_db() {
 	chown -R mysql:mysql /var/lib/mysql
@@ -40,3 +42,4 @@ set -e
 
 start_db
 mysql_upgrade -u $ADMIN_USER
+mysql -u $ADMIN_USER < <(sed -e "s/!ZU!/${ZODB_USER}/g" -e "s/!EU!/${ZEP_USER}/g" /opt/zenoss/bin/fix_permissions.sql.in)


### PR DESCRIPTION
The permissions of an upgraded database should match an initial database.

Fixes ZEN-33446.

(cherry picked from commit 718b15ffa5765c2dd05ac39b5b57aa132095c6e0)